### PR TITLE
Status of "git specs" such as BrowserID need to be clarified

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -352,7 +352,6 @@
         "href": "https://github.com/mozilla/id-specs/blob/prod/browserid/index.md",
         "title": "BrowserID",
         "date": "26 February 2013",
-        "status": "Production Specification",
         "publisher": "Mozilla"
     },
     "C14N-issues": {


### PR DESCRIPTION
Only using "WD" results in "W3C Working Draft" which is not what BrowserID is.  I've fixed that by using the term "Production Specification" for "status."
