### PR TITLE
hCard1.0 --> hCard (better ref token)

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -2785,7 +2785,7 @@
         "date": "15 January 2011",
         "status": "Putative TAG Finding"
     },
-    "hCard1.0": {
+    "hCard": {
         "authors": [
             "Tantek Celik",
             "Brian Suda"


### PR DESCRIPTION
The script parses "." adversely for ref tokens, but besides that fact, I think we shouldn't say "hCard1.0" anyway.
