### PR TITLE
Adding references to UTS22, UAX15, UAX35 and Unicode3.2

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -7853,7 +7853,7 @@
         "title": "Unicode Normalization Forms",
         "date": "31 August 2012",
         "status": "Unicode Standard Annex #15"
-    }
+    },
     "UAX21": {
         "authors": [
             "Mark Davis"
@@ -8066,7 +8066,15 @@
         "aliasOf": "unicode-xml"
     },
     "UNICODE310": "The Unicode Consortium. <a href=\"http://www.unicode.org/unicode/standard/versions/enumeratedversions.html#Unicode_3_1_0\"><cite>The Unicode Standard: Version 3.1.0.</cite></a> Addison Wesley Longman. 2000. ISBN 0-201-61633-5. For more information, consult the Unicode Consortium's home page at &lt;a href=&quot;http://www.unicode.org/&quot;&gt;http://www.unicode.org/&lt;/a&gt; URL: <a href=\"http://www.unicode.org/unicode/standard/versions/enumeratedversions.html#Unicode_3_1_0\">http://www.unicode.org/unicode/standard/versions/enumeratedversions.html#Unicode_3_1_0</a> ",
-    "UNICODE32": "The Unicode Consortium. <a href=\"http://www.unicode.org/versions/Unicode3.2.0/\"><cite>The Unicode Standard: Version 3.2.0.</cite></a> Addison Wesley Longman. 2000. ISBN 0-201-61633-5. For more information, consult the Unicode Consortium's home page at &lt;a href=&quot;http://www.unicode.org/&quot;&gt;http://www.unicode.org/&lt;/a&gt; URL: <a href=\"http://www.unicode.org/versions/Unicode3.2.0/\">http://www.unicode.org/versions/Unicode3.2.0/</a> ",
+    "UNICODE32": {
+         "authors": [
+             "The Unicode Consortium"
+         ],
+         "href": "http://www.unicode.org/versions/Unicode3.2.0/",
+         "title": "The Unicode Standard, Version 3.2.0",
+         "publisher": "Unicode Consortium",
+         "date": "27 March 2002",
+     },
     "UNICODE4": "The Unicode Consortium. <a href=\"http://www.unicode.org/versions/Unicode4.1.0/\"><cite>The Unicode Standard, Version 4.1.0.</cite></a> Defined by: The Unicode Standard, Version 4.0 (Boston, MA, Addison-Wesley, 2003. ISBN 0-321-18578-1), as amended by Unicode 4.0.1 (http://www.unicode.org/versions/Unicode4.0.1) and by Unicode 4.1.0 (http://www.unicode.org/versions/Unicode4.1.0) URL: <a href=\"http://www.unicode.org/versions/Unicode4.1.0/\">http://www.unicode.org/versions/Unicode4.1.0/</a> ",
     "UNICODE5": "The Unicode Consortium. <a href=\"http://www.unicode.org/versions/Unicode5.1.0/\"><cite>The Unicode Standard, Version 5.1.0.</cite></a> Addison-Wesley. 2007. ISBN 0-321-48091-0. URL: <a href=\"http://www.unicode.org/versions/Unicode5.1.0/\">http://www.unicode.org/versions/Unicode5.1.0/</a> ",
     "UPNP-AVARCH2": "John Ritchie, Thomas Kuehnel, Wouter van der Beek, Jeffrey Kang. <a href=\"http://www.upnp.org/specs/av/UPnP-av-AVArchitecture-v2-20101231.pdf\"><cite>UPnP AV Architecture:2</cite></a>. 31 December 2010. UPnP Forum. Standardized DCP. For UPnP Version 1.0. PDF document. URL: <a href=\"http://www.upnp.org/specs/av/UPnP-av-AVArchitecture-v2-20101231.pdf\">http://www.upnp.org/specs/av/UPnP-av-AVArchitecture-v2-20101231.pdf</a>",
@@ -8139,7 +8147,7 @@
          "title": "Unicode Character Mapping Markup Language (CharMapML)",
          "date": "09 September 2009",
          "status": "Unicode Technical Standard #22"
-    }
+    },
     "UWA-personalization-roadmap": {
         "authors": [
             "Andy Heath",


### PR DESCRIPTION
Added references needed by W3C/WHAT-WG Encoding spec and the W3C-I18N document Charmod-Norm. This includes UTS#22, UAX#15, UAX#35, and Unicode version 3.2.0.
