### PR TITLE
Expose versions.

### DIFF
--- a/lib/bibref.js
+++ b/lib/bibref.js
@@ -184,15 +184,16 @@ function cleanupRefs(refs) {
                     delete ref[prop];
                 }
                 if (prop == "deliveredBy") {
-                    ref[prop] = ref[prop].map(function(url) {
+                    ref.deliveredBy = ref.deliveredBy.map(function(url) {
                         return { url: url, shortname: _getWGShortNameFromURL(url) };
                     });
                 }
                 if (prop == "versions") {
-                    ref[prop] = Object.keys(ref[prop]).map(function(subKey) {
+                    ref.versions = Object.keys(ref[prop]).map(function(subKey) {
                         return k + "-" + subKey;
                     });
-                    ref[prop].sort();
+                    ref.versions.sort();
+                    ref.versions.reverse();
                 }
             }
         }

--- a/lib/bibref.js
+++ b/lib/bibref.js
@@ -15,6 +15,7 @@ var PROPS =  [
     "status",
     "publisher",
     "aliasOf",
+    "versions",
     "versionOf",
     "deliveredBy"
 ];
@@ -174,19 +175,25 @@ function createUppercaseRefs(refs) {
 }
 
 function cleanupRefs(refs) {
-    Object.keys(refs).forEach(function(ref) {
-        ref = refs[ref];
+    Object.keys(refs).forEach(function(k) {
+        var ref = refs[k];
         if (typeof ref === 'object') {
             if (ref.rawDate) ref.date = formatDate(ref.rawDate);
             for (var prop in ref) {
                 if (PROPS.indexOf(prop) === -1) {
                     delete ref[prop];
                 }
-		if (prop == "deliveredBy") {
-		    ref[prop] = ref[prop].map(function(url) {
-			return { url: url, shortname: _getWGShortNameFromURL(url) };
-		    });
-		}
+                if (prop == "deliveredBy") {
+                    ref[prop] = ref[prop].map(function(url) {
+                        return { url: url, shortname: _getWGShortNameFromURL(url) };
+                    });
+                }
+                if (prop == "versions") {
+                    ref[prop] = Object.keys(ref[prop]).map(function(subKey) {
+                        return k + "-" + subKey;
+                    });
+                    ref[prop].sort();
+                }
             }
         }
     });

--- a/test/bibref.js
+++ b/test/bibref.js
@@ -38,18 +38,18 @@ suite('Test bibref api', function() {
             foo: {
                 versions: {},
                 rawDate: "2012-1-1",
-		deliveredBy: [ "http://www.w3.org/html/wg/" ],
+                deliveredBy: [ "http://www.w3.org/html/wg/" ],
                 bar: 123
             }
         });
         var foo = cleanedup.foo;
-        assert.ok(!('versions' in foo));
+        assert.ok(typeof foo.versions == "object", "The versions property is an array of identifiers.");
         assert.ok(!('rawDate' in foo));
         assert.ok('date' in foo);
         assert.ok(!('bar' in foo));
-	assert.ok(typeof foo.deliveredBy[0] == "object", "The deliveredBy property of ref is an array objects.");
-	assert.ok('shortname' in foo.deliveredBy[0], "The deliveredBy property of ref has a shortname property.");
-	assert.equal(foo.deliveredBy[0].shortname, 'html', "The url http://www.w3.org/html/wg/ gets properly turned into the html shortname.");
+        assert.ok(typeof foo.deliveredBy[0] == "object", "The deliveredBy property of ref is an array objects.");
+        assert.ok('shortname' in foo.deliveredBy[0], "The deliveredBy property of ref has a shortname property.");
+        assert.equal(foo.deliveredBy[0].shortname, 'html', "The url http://www.w3.org/html/wg/ gets properly turned into the html shortname.");
     });
 
     test('bibref.findLatest finds the latest version of the ref', function() {


### PR DESCRIPTION
This exposes the version ID of specs when present. So for example, instead of exposing the following for HTML5:

```json
{
    "html5": {
        "authors": [
            "Ian Hickson",
            "Robin Berjon",
            "Steve Faulkner",
            "Travis Leithead",
            "Erika Doyle Navara",
            "Edward O'Connor",
            "Silvia Pfeiffer"
        ],
        "date": "28 October 2014",
        "deliveredBy": [
            {
                "shortname": "html",
                "url": "http://www.w3.org/html/wg/"
            }
        ],
        "edDraft": "http://www.w3.org/html/wg/drafts/html/master/",
        "href": "http://www.w3.org/TR/html5/",
        "id": "html5",
        "publisher": "W3C",
        "status": "REC",
        "title": "HTML5"
    }
}
```

This is exposed instead:

```JSON
{
    "html5": {
        "authors": [
            "Ian Hickson",
            "Robin Berjon",
            "Steve Faulkner",
            "Travis Leithead",
            "Erika Doyle Navara",
            "Edward O'Connor",
            "Silvia Pfeiffer"
        ],
        "date": "28 October 2014",
        "deliveredBy": [
            {
                "shortname": "html",
                "url": "http://www.w3.org/html/wg/"
            }
        ],
        "edDraft": "http://www.w3.org/html/wg/drafts/html/master/",
        "href": "http://www.w3.org/TR/html5/",
        "id": "html5",
        "publisher": "W3C",
        "status": "REC",
        "title": "HTML5",
        "versions": [
            "html5-20080122",
            "html5-20080610",
            "html5-20090212",
            "html5-20090423",
            "html5-20090825",
            "html5-20100304",
            "html5-20100624",
            "html5-20101019",
            "html5-20110113",
            "html5-20110405",
            "html5-20110525",
            "html5-20120329",
            "html5-20121025",
            "html5-20121217",
            "html5-20130806",
            "html5-20140204",
            "html5-20140429",
            "html5-20140617",
            "html5-20140731",
            "html5-20140916",
            "html5-20141028"
        ]
    }
}
```