### PR TITLE
Add Dave Longley to list of spec authors for JSON-LD.

### DIFF
--- a/refs/w3c.json
+++ b/refs/w3c.json
@@ -27116,6 +27116,7 @@
     "json-ld": {
         "authors": [
             "Manu Sporny",
+            "Dave Longley",
             "Gregg Kellogg",
             "Markus Lanthaler"
         ],
@@ -27138,6 +27139,7 @@
             "20130411": {
                 "authors": [
                     "Manu Sporny",
+                    "Dave Longley",
                     "Gregg Kellogg",
                     "Markus Lanthaler"
                 ],
@@ -27154,6 +27156,7 @@
             "20130910": {
                 "authors": [
                     "Manu Sporny",
+                    "Dave Longley",
                     "Gregg Kellogg",
                     "Markus Lanthaler"
                 ],
@@ -27170,6 +27173,7 @@
             "20131105": {
                 "authors": [
                     "Manu Sporny",
+                    "Dave Longley",
                     "Gregg Kellogg",
                     "Markus Lanthaler"
                 ],
@@ -27186,6 +27190,7 @@
             "20140116": {
                 "authors": [
                     "Manu Sporny",
+                    "Dave Longley",
                     "Gregg Kellogg",
                     "Markus Lanthaler"
                 ],
@@ -27204,6 +27209,7 @@
     "json-ld-api": {
         "authors": [
             "Markus Lanthaler",
+            "Dave Longley",
             "Gregg Kellogg",
             "Manu Sporny"
         ],
@@ -27232,6 +27238,7 @@
             "20130516": {
                 "authors": [
                     "Markus Lanthaler",
+                    "Dave Longley",
                     "Gregg Kellogg",
                     "Manu Sporny"
                 ],
@@ -27248,6 +27255,7 @@
             "20130910": {
                 "authors": [
                     "Markus Lanthaler",
+                    "Dave Longley",
                     "Gregg Kellogg",
                     "Manu Sporny"
                 ],
@@ -27264,6 +27272,7 @@
             "20131105": {
                 "authors": [
                     "Markus Lanthaler",
+                    "Dave Longley",
                     "Gregg Kellogg",
                     "Manu Sporny"
                 ],
@@ -27280,6 +27289,7 @@
             "20140116": {
                 "authors": [
                     "Markus Lanthaler",
+                    "Dave Longley",
                     "Gregg Kellogg",
                     "Manu Sporny"
                 ],


### PR DESCRIPTION
The JSON-LD specs in the specref database don't list Dave Longley because the entries are created by just looking at the Editor fields. In the particular case of the JSON-LD specs, Dave Longley contributed a non-trivial number of fundamental concepts and algorithms to the core of the language and I had realized a while ago that he was erroneously not listed at all in the spec refs. Finally getting around to fixing this issue.