### PR TITLE
Add IEEE-754, OMGIDL, and PERLRE.

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -891,6 +891,12 @@
     "ICE": {
         "aliasOf": "RFC5245"
     },
+    "IEEE-754": {
+        "href": "http://ieeexplore.ieee.org/servlet/opac?punumber=4610933",
+        "title": "IEEE Standard for Binary Floating-Point Arithmetic (ANSI/IEEE Std 754-1985)",
+        "publisher": "Institute of Electrical and Electronics Engineers",
+        "date": "29 Aug 2008"
+    },
     "IMAGEMAP": {
         "aliasOf": "NOTE-imagemap"
     },
@@ -1279,6 +1285,12 @@
         "date": "26 June 2008",
         "publisher": "OMA"
     },
+    "OMGIDL": {
+        "href": "http://www.omg.org/cgi-bin/doc?formal/08-01-04.pdf",
+        "title": "CORBA 3.1 – OMG IDL Syntax and Semantics chapter",
+        "publisher": "Object Management Group",
+        "date": "January 2008"
+    },
     "ORIGIN": {
         "aliasOf": "RFC6454"
     },
@@ -1287,6 +1299,12 @@
     },
     "P3P1.0": {
         "aliasOf": "P3P"
+    },
+    "PERLRE": {
+        "href": "http://search.cpan.org/dist/perl/pod/perlre.pod",
+        "title": "Perl regular expressions (Perl 5.8.8)",
+        "publisher": "The Perl Foundation",
+        "date": "February 2006"
     },
     "PERMACOOKIE": {
         "authors": [


### PR DESCRIPTION
WebIDL has a few references that aren't in SpecRef yet.