### PR TITLE
Mark meta-theme-color as obsolete.

### DIFF
--- a/refs/whatwg.json
+++ b/refs/whatwg.json
@@ -263,6 +263,9 @@
         "href": "https://github.com/whatwg/meta-theme-color",
         "publisher": "WHATWG",
         "status": "Living Standard",
-        "title": "The 'theme-color' meta extension"
+        "title": "The 'theme-color' meta extension",
+        "obsoletedBy": [
+            "HTML"
+        ]
     }
 }


### PR DESCRIPTION
Closes #252.