### PR TITLE
Tightened up the DCMI terms in refs.json

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -506,9 +506,6 @@
         "date": "14 June 2012",
         "status": "DCMI Recommendation"
     },
-    "dcterms": {
-        "aliasOf": "DCTERMS"
-    },
     "DC11": {
         "authors": [
             "Dublin Core metadata initiative"
@@ -517,9 +514,6 @@
         "title": "Dublin Core Metadata Element Set, Version 1.1",
         "date": "14 June 2012",
         "status": "DCMI recommendation"
-    },
-    "dc11": {
-        "aliasOf": "DC11"
     },
     "DCAT-UCR": {
         "authors": [

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -497,14 +497,29 @@
         "date": "14 January 2008",
         "status": "DCMI Recommendation"
     },
-    "DC11": {
+    "DCTERMS" : {
         "authors": [
             "Dublin Core metadata initiative"
         ],
         "href": "http://dublincore.org/documents/dcmi-terms/",
-        "title": "Dublin Core metadata element set, version 1.1",
-        "date": "July 1999",
-        "status": "Dublin Core recommendation"
+        "title": "DCMI Metadata Terms",
+        "date": "14 June 2012",
+        "status": "DCMI Recommendation"
+    },
+    "dcterms": {
+        "aliasOf": "DCTERMS"
+    },
+    "DC11": {
+        "authors": [
+            "Dublin Core metadata initiative"
+        ],
+        "href": "http://dublincore.org/documents/2012/06/14/dces/",
+        "title": "Dublin Core Metadata Element Set, Version 1.1",
+        "date": "14 June 2012",
+        "status": "DCMI recommendation"
+    },
+    "dc11": {
+        "aliasOf": "DC11"
     },
     "DCAT-UCR": {
         "authors": [


### PR DESCRIPTION
DCMI makes a difference between DC11 and DCTERMS (the former is a subset and less precisely specified version of the latter), and the current references mixed the two. The dates were also outdated.

There is a DC-TERMS references in the legacy file, too, I am not sure what to do with that one. It is correct, but the date is old. Is it possible to alias to the new version instead? I am not sure how legacy is used

Cc: @tobie 