### PR TITLE
Update Authoring Practices editors draft URL

### DIFF
--- a/refs/w3c.json
+++ b/refs/w3c.json
@@ -54698,7 +54698,7 @@
         "rawDate": "2016-03-17",
         "status": "WD",
         "publisher": "W3C",
-        "edDraft": "https://w3c.github.io/aria/practices/aria-practices.html",
+        "edDraft": "http://w3c.github.io/aria-practices/",
         "deliveredBy": [
             "http://www.w3.org/WAI/ARIA/"
         ],


### PR DESCRIPTION
The APG has been split off into its own repo, so it also has a new ED.