### PR TITLE
Add FIDO AppID and Facet Specification

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -975,6 +975,12 @@
         "href": "https://extensiblewebmanifesto.org/",
         "rawDate": "2013-06-10"
     },
+    "FIDO-APPID": {
+        "title": "FIDO AppID and Facet Specification",
+        "href": "https://fidoalliance.org/specs/fido-appid-and-facets-ps-20150514.pdf",
+        "publisher": "FIDO Alliance",
+        "rawDate": "2015-05-14"
+    },
     "FILE-API": {
         "aliasOf": "FileAPI"
     },


### PR DESCRIPTION
Add the FIDO Alliance AppID and Facet Specification.  This will be immediately useful for the webauthn w3c specification.