### PR TITLE
Corrected title for "browserext-native"

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -220,7 +220,6 @@
         ],
         "href": "https://browserext.github.io/browserext/",
         "title": "Browser Extensions",
-        "date": "October 2016",
         "rawDate": "2016-10",
         "publisher": "W3C",
         "status": "Draft Community Group Report"    
@@ -232,7 +231,6 @@
         ],
         "href": "https://browserext.github.io/native-messaging/",
         "title": "Browser Extensions",
-        "date": "October 2016",
         "rawDate": "2016-10",
         "publisher": "W3C",
         "status": "Draft Community Group Report"    

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "3GPP-TT": {
         "title": "Transparent end-to-end Packet switched Streaming Service (PSS) Timed text format (Release 12)",
         "href": "http://www.3gpp.org/ftp/Specs/archive/26_series/26.245/26245-c00.zip",

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -230,7 +230,7 @@
             "Mike Pietraszak"
         ],
         "href": "https://browserext.github.io/native-messaging/",
-        "title": "Browser Extensions",
+        "title": "Native Messaging for Browser Extensions",
         "rawDate": "2016-10",
         "publisher": "W3C",
         "status": "Draft Community Group Report"    

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "3GPP-TT": {
         "title": "Transparent end-to-end Packet switched Streaming Service (PSS) Timed text format (Release 12)",
         "href": "http://www.3gpp.org/ftp/Specs/archive/26_series/26.245/26245-c00.zip",
@@ -213,6 +213,29 @@
         "date": "2 June 2010",
         "href": "http://bondi.omtp.org/1.11/apis/apifeatures.html",
         "title": "BONDI API Features v1.11"
+    },
+    "browserext": {
+        "authors": [
+            "Mike Pietraszak"
+        ],
+        "href": "https://browserext.github.io/browserext/",
+        "title": "Browser Extensions",
+        "date": "October 2016",
+        "rawDate": "2016-10",
+        "publisher": "W3C",
+        "status": "Draft Community Group Report"    
+    },
+    "browserext-native": {
+        "authors": [
+            "Andrew Swan",
+            "Mike Pietraszak"
+        ],
+        "href": "https://browserext.github.io/native-messaging/",
+        "title": "Browser Extensions",
+        "date": "October 2016",
+        "rawDate": "2016-10",
+        "publisher": "W3C",
+        "status": "Draft Community Group Report"    
     },
     "BrowserID": {
         "authors": [

--- a/refs/w3c.json
+++ b/refs/w3c.json
@@ -739,6 +739,27 @@
     "ATAG20-TECHS": {
         "aliasOf": "IMPLEMENTING-ATAG20"
     },
+    "browserext": {
+        "authors": [
+            "Mike Pietraszak"
+        ],
+        "href": "https://browserext.github.io/browserext/",
+        "title": "Browser Extensions",
+        "date": "October 2016",
+        "publisher": "W3C",
+        "status": "Draft Community Group Report"    
+    },
+    "browserext-native": {
+        "authors": [
+            "Andrew Swan",
+            "Mike Pietraszak"
+        ],
+        "href": "https://browserext.github.io/native-messaging/",
+        "title": "Browser Extensions",
+        "date": "October 2016",
+        "publisher": "W3C",
+        "status": "Draft Community Group Report"    
+    },
     "C14N-issues": {
         "authors": [
             "José Kahan",

--- a/refs/w3c.json
+++ b/refs/w3c.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "2dcontext": {
         "authors": [
             "Rik Cabanier",
@@ -738,27 +738,6 @@
     },
     "ATAG20-TECHS": {
         "aliasOf": "IMPLEMENTING-ATAG20"
-    },
-    "browserext": {
-        "authors": [
-            "Mike Pietraszak"
-        ],
-        "href": "https://browserext.github.io/browserext/",
-        "title": "Browser Extensions",
-        "date": "October 2016",
-        "publisher": "W3C",
-        "status": "Draft Community Group Report"    
-    },
-    "browserext-native": {
-        "authors": [
-            "Andrew Swan",
-            "Mike Pietraszak"
-        ],
-        "href": "https://browserext.github.io/native-messaging/",
-        "title": "Browser Extensions",
-        "date": "October 2016",
-        "publisher": "W3C",
-        "status": "Draft Community Group Report"    
     },
     "C14N-issues": {
         "authors": [

--- a/refs/w3c.json
+++ b/refs/w3c.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "2dcontext": {
         "authors": [
             "Rik Cabanier",


### PR DESCRIPTION
Changed to "Native Messaging for Browser Extensions" from "Browser Extensions"