### PR TITLE
Update to HTTPS where possible

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -25,7 +25,7 @@
         "aliasOf": "RFC5234"
     },
     "AD-INDUSTRY": {
-        "href": "http://www.iab.net/media/file/ven-principles-07-01-09.pdf",
+        "href": "https://www.iab.net/media/file/ven-principles-07-01-09.pdf",
         "title": "Self-Regulatory Principles for Online Behavioral Advertising",
         "publisher": "American Association of Advertising Industries",
         "etAl": true,
@@ -65,7 +65,7 @@
         "aliasOf": "ANSI-X9-44"
     },
     "ANSI-X9-62": {
-        "href": "http://webstore.ansi.org/RecordDetail.aspx?sku=ANSI+X9.62%3a2005",
+        "href": "https://webstore.ansi.org/RecordDetail.aspx?sku=ANSI+X9.62%3a2005",
         "title": "Public Key Cryptography for the Financial Services Industry, The Elliptic Curve Digital Signature Algorithm (ECDSA)",
         "date": "2005",
         "publisher": "ANSI"
@@ -237,7 +237,7 @@
         "title": "Creative Commons: About Licenses"
     },
     "CC-CHOOSE": {
-        "href": "http://creativecommons.org/choose/",
+        "href": "https://creativecommons.org/choose/",
         "title": "Creative Commons: License Your Work"
     },
     "CCPP": {
@@ -266,7 +266,7 @@
         "aliasOf": "NOTE-cgm"
     },
     "CHARSETS": {
-        "href": "http://www.iana.org/assignments/character-sets",
+        "href": "https://www.iana.org/assignments/character-sets",
         "title": "Character sets"
     },
     "CHIPS": {
@@ -328,7 +328,7 @@
         "title": "User Stories Applied: For Agile Software Development",
         "date": "2004",
         "publisher": "Addison Wesley Longman Publishing Co., Inc., Redwood City, CA, USA.",
-        "href": "http://www.mountaingoatsoftware.com/books/user-stories-applied"
+        "href": "https://www.mountaingoatsoftware.com/books/user-stories-applied"
     },
     "COLORIMETRY": {
         "title": "Colorimetry, Second Edition",
@@ -369,7 +369,7 @@
         "authors": [
             "Robin Berjon"
         ],
-        "href": "http://dev.w3.org/2009/dap/device/",
+        "href": "https://dev.w3.org/2009/dap/device/",
         "title": "Core Device Interfaces",
         "date": "2 December 2009",
         "status": "ED",
@@ -379,7 +379,7 @@
         "authors": [
             "Y. Naruse"
         ],
-        "href": "http://www.iana.org/assignments/charset-reg/CP50220",
+        "href": "https://www.iana.org/assignments/charset-reg/CP50220",
         "title": "CP50220",
         "publisher": "IANA"
     },
@@ -475,7 +475,7 @@
             "Bert Bos",
             "David Hyatt"
         ],
-        "href": "http://dev.w3.org/csswg/css3-tables/",
+        "href": "https://dev.w3.org/csswg/css3-tables/",
         "title": "CSS3 Tables Module",
         "date": "13 November 2012",
         "status": "ED",
@@ -506,7 +506,7 @@
             "Koji Ishii",
             "Shinyu Murakami"
         ],
-        "href": "http://dev.w3.org/csswg/css3-writing-modes",
+        "href": "https://dev.w3.org/csswg/css3-writing-modes",
         "title": "CSS Writing Modes Module Level 3",
         "date": "17 October 2010",
         "status": "ED",
@@ -559,7 +559,7 @@
         "aliasOf": "rdfa-core-20130822"
     },
     "CVE-2009-0217": {
-        "href": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-0217",
+        "href": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-0217",
         "title": "Common Vulnerabilities and Exposures List, CVE-2009-0217"
     },
     "Coloring-RDF": {
@@ -636,7 +636,7 @@
             "F. Hirsch",
             "D. Rogers"
         ],
-        "href": "http://dev.w3.org/2009/dap/policy-reqs/",
+        "href": "https://dev.w3.org/2009/dap/policy-reqs/",
         "title": "Device API Access Control Requirements",
         "date": "17 June 2010",
         "status": "ED",
@@ -650,7 +650,7 @@
             "F. Hirsch",
             "D. Rogers"
         ],
-        "href": "http://dev.w3.org/2009/dap/policy/Framework.html",
+        "href": "https://dev.w3.org/2009/dap/policy/Framework.html",
         "title": "Device API Policy Framework",
         "date": "17 June 2010",
         "status": "ED",
@@ -677,7 +677,7 @@
             "F Hirsch",
             "D. Rogers"
         ],
-        "href": "http://dev.w3.org/2009/dap/policy/Profile.html",
+        "href": "https://dev.w3.org/2009/dap/policy/Profile.html",
         "title": "XACML Policy Profile for Device APIs",
         "date": "17 June 2010",
         "status": "ED",
@@ -694,7 +694,7 @@
         "authors": [
             "D. Davis"
         ],
-        "href": "http://www.usenix.org/publications/library/proceedings/usenix01/davis.html",
+        "href": "https://www.usenix.org/publications/library/proceedings/usenix01/davis.html",
         "title": "Defective Sign &amp; Encrypt in S/MIME, PKCS#7, MOSS, PEM, PGP, and XML",
         "publisher": "USENIX Annual Technical Conference",
         "date": "2001"
@@ -729,7 +729,7 @@
             "R. Cyganiak",
             "F. Maali."
         ],
-        "href": "http://dvcs.w3.org/hg/gld/raw-file/default/dcat-ucr/index.html",
+        "href": "https://dvcs.w3.org/hg/gld/raw-file/default/dcat-ucr/index.html",
         "title": "Use Cases and Requirements for the Data Catalog Vocabulary",
         "date": "16 December 2012",
         "status": "ED",
@@ -835,7 +835,7 @@
     },
     "DTMF": {
         "date": "1 November 1988",
-        "href": "http://www.itu.int/rec/T-REC-Q.23/en",
+        "href": "https://www.itu.int/rec/T-REC-Q.23/en",
         "publisher": "International Telecommunication Union",
         "status": "In force",
         "title": "Q.23 : Technical features of push-button telephone sets"
@@ -919,7 +919,7 @@
     },
     "ECMA-404": {
         "date": "1 October 2013",
-        "href": "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf",
+        "href": "https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf",
         "publisher": "Ecma International",
         "status": "Standard",
         "title": "The JSON Data Interchange Format"
@@ -1168,7 +1168,7 @@
     },
     "GraphQL": {
         "title": "GraphQL",
-        "href": "http://facebook.github.io/graphql/",
+        "href": "https://facebook.github.io/graphql/",
         "rawDate": "2015-07",
         "status": "Working Draft"
     },
@@ -1193,7 +1193,7 @@
         "authors": [
             "Ian Hickson"
         ],
-        "href": "http://dev.w3.org/html5/html-device/",
+        "href": "https://dev.w3.org/html5/html-device/",
         "title": "HTML Device",
         "date": "9 September 2010",
         "status": "ED",
@@ -1212,12 +1212,12 @@
         "aliasOf": "RFC7230"
     },
     "IANA-MEDIA-TYPES": {
-        "href": "http://www.iana.org/assignments/media-types/",
+        "href": "https://www.iana.org/assignments/media-types/",
         "title": "Media Types",
         "publisher": "IANA"
     },
     "IANA-RTP-2": {
-        "href": "http://www.iana.org/assignments/rtp-parameters/rtp-parameters.xhtml#rtp-parameters-2",
+        "href": "https://www.iana.org/assignments/rtp-parameters/rtp-parameters.xhtml#rtp-parameters-2",
         "title": "RTP Payload Format media types",
         "publisher": "IANA"
     },
@@ -1225,18 +1225,18 @@
         "authors": [
             "Paul Lindner"
         ],
-        "href": "http://www.iana.org/assignments/media-types/text/tab-separated-values",
+        "href": "https://www.iana.org/assignments/media-types/text/tab-separated-values",
         "title": "Definition of tab-separated-values (tsv)",
         "date": "June 1993",
         "status": "IANA Media Type Registration"
     },
     "IANA-URI-SCHEMES": {
-        "href": "http://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml",
+        "href": "https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml",
         "title": "Uniform Resource Identifier (URI) Schemes",
         "publisher": "IANA"
     },
     "IAccessible2": {
-        "href": "http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2",
+        "href": "https://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2",
         "title": "IAccessible2",
         "publisher": "Linux Foundation"
     },
@@ -1411,7 +1411,7 @@
         "authors": [
             "Robin Berjon"
         ],
-        "href": "http://dev.w3.org/2009/dap/docs/privacy-license.html",
+        "href": "https://dev.w3.org/2009/dap/docs/privacy-license.html",
         "title": "License-based Privacy: Technical Aspects",
         "date": "19 April 2010",
         "status": "W3C-Internal Document",
@@ -1511,12 +1511,12 @@
         "title": "ISO/IEC 23009-1:2014 Information technology -- Dynamic adaptive streaming over HTTP (DASH) -- Part 1: Media presentation description and segment formats"
     },
     "MSAA": {
-        "href": "http://msdn.microsoft.com/en-us/library/ms697707.aspx",
+        "href": "https://msdn.microsoft.com/en-us/library/ms697707.aspx",
         "title": "Microsoft Active Accessibility (MSAA) 2.0",
         "publisher": "Microsoft Corporation"
     },
     "MSDN-SETCAPTURE": {
-        "href": "http://msdn.microsoft.com/en-us/library/ms536742.aspx",
+        "href": "https://msdn.microsoft.com/en-us/library/ms536742.aspx",
         "title": "setCapture method",
         "publisher": "Microsoft Corporation"
     },
@@ -1672,7 +1672,7 @@
         "aliasOf": "rfc3533"
     },
     "OGGSKELETON": {
-        "href": "http://wiki.xiph.org/SkeletonHeaders",
+        "href": "https://wiki.xiph.org/SkeletonHeaders",
         "title": "Ogg Skeleton 4 Message Headers",
         "publisher": "Xiph.org Foundation",
         "date": "17 March 2014"
@@ -1708,7 +1708,7 @@
         "authors": [
             "Robert McMillan"
         ],
-        "href": "http://www.wired.com/2014/10/verizons-perma-cookie/",
+        "href": "https://www.wired.com/2014/10/verizons-perma-cookie/",
         "title": "Verizon's 'Perma-Cookie' Is a Privacy-Killing Machine",
         "publisher": "Wired"
     },
@@ -1743,7 +1743,7 @@
             "Frederick Hirsch",
             "David Rogers"
         ],
-        "href": "http://dev.w3.org/2009/dap/policy-reqs",
+        "href": "https://dev.w3.org/2009/dap/policy-reqs",
         "title": "Device API Policy Requirements",
         "date": "13 April 2010",
         "status": "ED",
@@ -1789,7 +1789,7 @@
             "M. Thomson"
         ],
         "date": "23 July 2014",
-        "href": "http://datatracker.ietf.org/doc/draft-ietf-rtcweb-alpn/",
+        "href": "https://datatracker.ietf.org/doc/draft-ietf-rtcweb-alpn/",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Application Layer Protocol Negotiation for Web Real-Time Communications"
@@ -1814,7 +1814,7 @@
             "M. Tuexen"
         ],
         "date": "14 October 2015",
-        "href": "http://datatracker.ietf.org/doc/draft-ietf-rtcweb-data-channel/",
+        "href": "https://datatracker.ietf.org/doc/draft-ietf-rtcweb-data-channel/",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "RTCWeb Data Channels"
@@ -1826,7 +1826,7 @@
             "M. Tuexen"
         ],
         "date": "14 October 2015",
-        "href": "http://datatracker.ietf.org/doc/draft-ietf-rtcweb-data-protocol/",
+        "href": "https://datatracker.ietf.org/doc/draft-ietf-rtcweb-data-protocol/",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "RTCWeb Data Channel Protocol"
@@ -1848,7 +1848,7 @@
             "Cullen Jennings"
         ],
         "date": "22 October 2013",
-        "href": "http://datatracker.ietf.org/doc/draft-ietf-rtcweb-jsep/",
+        "href": "https://datatracker.ietf.org/doc/draft-ietf-rtcweb-jsep/",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Javascript Session Establishment Protocol"
@@ -1858,7 +1858,7 @@
             "H. Alvestrand"
         ],
         "date": "14 February 2014",
-        "href": "http://datatracker.ietf.org/doc/draft-ietf-rtcweb-overview/",
+        "href": "https://datatracker.ietf.org/doc/draft-ietf-rtcweb-overview/",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Overview: Real Time Protocols for Brower-based Applications"
@@ -1870,7 +1870,7 @@
             "J. Ott"
         ],
         "date": "17 March 2016",
-        "href": "http://datatracker.ietf.org/doc/draft-ietf-rtcweb-rtp-usage/",
+        "href": "https://datatracker.ietf.org/doc/draft-ietf-rtcweb-rtp-usage/",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Web Real-Time Communication (WebRTC): Media Transport and Use of RTP"
@@ -1880,7 +1880,7 @@
             "Eric Rescorla"
         ],
         "date": "22 January 2014",
-        "href": "http://datatracker.ietf.org/doc/draft-ietf-rtcweb-security/",
+        "href": "https://datatracker.ietf.org/doc/draft-ietf-rtcweb-security/",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Security Considerations for WebRTC"
@@ -1890,7 +1890,7 @@
             "Eric Rescorla"
         ],
         "date": "10 December 2016",
-        "href": "http://datatracker.ietf.org/doc/draft-ietf-rtcweb-security-arch/",
+        "href": "https://datatracker.ietf.org/doc/draft-ietf-rtcweb-security-arch/",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "WebRTC Security Architecture"
@@ -1900,7 +1900,7 @@
             "H. Alvestrand"
         ],
         "date": "31 October 2016",
-        "href": "http://datatracker.ietf.org/doc/draft-ietf-rtcweb-transports/",
+        "href": "https://datatracker.ietf.org/doc/draft-ietf-rtcweb-transports/",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Transports for RTCWEB"
@@ -2235,7 +2235,7 @@
         "aliasOf": "BIDI"
     },
     "UI-AUTOMATION": {
-        "href": "http://msdn.microsoft.com/en-us/library/ee684009%28v=vs.85%29.aspx",
+        "href": "https://msdn.microsoft.com/en-us/library/ee684009%28v=vs.85%29.aspx",
         "title": "UI Automation",
         "publisher": "Microsoft Corporation"
     },
@@ -2384,7 +2384,7 @@
             "James Hawkins",
             "Paul Kinlan"
         ],
-        "href": "http://dvcs.w3.org/hg/web-intents/raw-file/tip/spec/Overview.html",
+        "href": "https://dvcs.w3.org/hg/web-intents/raw-file/tip/spec/Overview.html",
         "title": "Web Intents",
         "status": "ED",
         "publisher": "W3C"
@@ -2418,7 +2418,7 @@
         "authors": [
             "Marcos Cáceres"
         ],
-        "href": "http://dev.w3.org/2006/waf/widgets/imp-report/",
+        "href": "https://dev.w3.org/2006/waf/widgets/imp-report/",
         "title": "Implementation Report for Widgets Packaging and XML Configuration"
     },
     "WIDGETS-PC-TESTS": {
@@ -2426,7 +2426,7 @@
             "Marcos Cáceres"
         ],
         "title": "Test Suite for Packaging and XML Configuration",
-        "href": "http://dev.w3.org/2006/waf/widgets/test-suite/"
+        "href": "https://dev.w3.org/2006/waf/widgets/test-suite/"
     },
     "WebIDL-2": {
         "aliasOf": "WebIDL-LS"
@@ -2461,7 +2461,7 @@
         "publisher": "ITU"
     },
     "X690": {
-        "href": "http://www.itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf",
+        "href": "https://www.itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf",
         "title": "Recommendation X.690 — Information Technology — ASN.1 Encoding Rules — Specification of Basic Encoding Rules (BER), Canonical Encoding Rules (CER), and Distinguished Encoding Rules (DER)",
         "publisher": "ITU"
     },
@@ -2475,7 +2475,7 @@
             "Joe Hildebrand"
         ],
         "date": "23 December 2009",
-        "href": "http://xmpp.org/extensions/xep-0166.html",
+        "href": "https://xmpp.org/extensions/xep-0166.html",
         "publisher": "XMPP Standards Foundation",
         "status": "Draft Standard",
         "title": "XEP-0166: Jingle",
@@ -2577,7 +2577,7 @@
             "Kenneth G. Paterson",
             "Juraj Somorovsky"
         ],
-        "href": "http://www.nds.ruhr-uni-bochum.de/research/publications/backwards-compatibility/",
+        "href": "https://www.nds.ruhr-uni-bochum.de/research/publications/backwards-compatibility/",
         "title": "One Bad Apple: Backwards Compatibility Attacks on State-of-the-Art Cryptography",
         "date": "2013"
     },
@@ -2586,7 +2586,7 @@
             "Tibor Jager",
             "Juraj Somorovsky"
         ],
-        "href": "http://www.nds.ruhr-uni-bochum.de/research/publications/breaking-xml-encryption/",
+        "href": "https://www.nds.ruhr-uni-bochum.de/research/publications/breaking-xml-encryption/",
         "title": "How to Break XML Encryption",
         "date": "22 October 2011"
     },
@@ -2691,7 +2691,7 @@
     },
     "ZIP": {
         "date": "1 September 2012",
-        "href": "http://www.pkware.com/documents/casestudies/APPNOTE.TXT",
+        "href": "https://www.pkware.com/documents/casestudies/APPNOTE.TXT",
         "status": "Final",
         "title": ".ZIP File Format Specification"
     },


### PR DESCRIPTION
There are 48 URls in `biblio.json` which *were* `http` but which support `https`.  This PR upgrades them.

Fixes #340 

### Timeouts

My checks timed-out after 5 seconds. It is possible that there are some (slow) servers which I missed.

### 404s

There were 3 additional URIs which support `https` but returned a 404. These also 404 on the `http` version.  I haven't changed them. They are:

* http://www.ce.org/Standards/browseByCommittee_2757.asp
* http://www.ce.org/Standards/Standard-Listings/R4-3-Television-Data-Systems-Subcommittee/CEA-708-D.aspx
* http://www.jpeg.org/cd15444-1.pdf

