### PR TITLE
Update some UAX entries

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -186,9 +186,9 @@
             "Aharon Lanin",
             "Andrew Glass"
         ],
-        "href": "http://www.unicode.org/reports/tr9/",
+        "href": "http://www.unicode.org/reports/tr9/tr9-35.html",
         "publisher": "Unicode Consortium",
-        "rawDate": "2014-06-05",
+        "rawDate": "18 May 2016",
         "status": "Unicode Standard Annex #9",
         "title": "Unicode Bidirectional Algorithm"
     },
@@ -2136,21 +2136,21 @@
     },
     "UAX11": {
         "authors": [
-            "Asmus Freytag"
+            "Ken Lunde 小林劍"
         ],
-        "href": "http://www.unicode.org/unicode/reports/tr11/tr11-8.html",
+        "href": "http://www.unicode.org/reports/tr11/tr11-31.html",
         "title": "East Asian Width",
-        "date": "23 March 2001",
+        "date": "18 May 2016",
         "status": "Unicode Standard Annex #11",
         "publisher": "Unicode Consortium"
     },
     "UAX14": {
         "authors": [
-            "Asmus Freytag"
+            "Andy Heninger"
         ],
-        "href": "http://www.unicode.org/unicode/reports/tr14/tr14-17.html",
-        "title": "Line Breaking Properties",
-        "date": "29 March 2005",
+        "href": "http://www.unicode.org/reports/tr14/tr14-37.html",
+        "title": "Unicode Line Breaking Algorithm",
+        "date": "01 June 2016",
         "status": "Unicode Standard Annex #14",
         "publisher": "Unicode Consortium"
     },
@@ -2159,9 +2159,9 @@
             "Mark Davis",
             "Ken Whistler"
         ],
-        "href": "http://www.unicode.org/reports/tr15",
+        "href": "http://www.unicode.org/reports/tr15/tr15-44.html",
         "title": "Unicode Normalization Forms",
-        "date": "31 August 2012",
+        "date": "24 February 2016",
         "status": "Unicode Standard Annex #15",
         "publisher": "Unicode Consortium"
     },
@@ -2177,11 +2177,12 @@
     },
     "UAX24": {
         "authors": [
-            "Mark Davis"
+            "Mark Davis",
+	    "Ken Whistler"
         ],
-        "href": "http://www.unicode.org/unicode/reports/tr24/tr24-7.html",
-        "title": "Script Names",
-        "date": "28 March 2005",
+        "href": "http://www.unicode.org/reports/tr24/tr24-26.html",
+        "title": "Unicode Script Property",
+        "date": "18 May 2016",
         "status": "Unicode Standard Annex #24",
         "publisher": "Unicode Consortium"
     },
@@ -2199,11 +2200,12 @@
     },
     "UAX29": {
         "authors": [
-            "Mark Davis"
+            "Mark Davis",
+	    "Laurențiu Iancu"
         ],
-        "href": "http://www.unicode.org/unicode/reports/tr29/tr29-9.html",
-        "title": "Text Boundaries",
-        "date": "25 March 2005",
+        "href": "http://www.unicode.org/reports/tr29/tr29-29.html",
+        "title": "Unicode Text Segmentation",
+        "date": "20 June 2016",
         "status": "Unicode Standard Annex #29",
         "publisher": "Unicode Consortium"
     },
@@ -2212,9 +2214,9 @@
             "Mark Davis",
             "CLDR committee members"
         ],
-        "href": "http://www.unicode.org/reports/tr35/tr35-31/tr35.html",
+        "href": "http://www.unicode.org/reports/tr35/tr35-47/tr35.html",
         "title": "Unicode Locale Data Markup Language (LDML)",
-        "date": "15 March 2013",
+        "date": "15 March 2017",
         "status": "Unicode Standard Annex #35",
         "publisher": "Unicode Consortium"
     },

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -188,7 +188,7 @@
         ],
         "href": "http://www.unicode.org/reports/tr9/tr9-35.html",
         "publisher": "Unicode Consortium",
-        "rawDate": "18 May 2016",
+        "date": "18 May 2016",
         "status": "Unicode Standard Annex #9",
         "title": "Unicode Bidirectional Algorithm"
     },
@@ -2150,7 +2150,7 @@
         ],
         "href": "http://www.unicode.org/reports/tr14/tr14-37.html",
         "title": "Unicode Line Breaking Algorithm",
-        "date": "01 June 2016",
+        "date": "1 June 2016",
         "status": "Unicode Standard Annex #14",
         "publisher": "Unicode Consortium"
     },


### PR DESCRIPTION
Points UAX* bibliographic entries to their latest incarnation,
updating relevant metadata (authors, date, title) accordingly.

Not included in this commit are those that have been superseded (UAX21
& UAX27). See https://github.com/w3c/csswg-drafts/issues/1169#issuecomment-291779023