### PR TITLE
Update entries for macOS's NSAccessibility protocol

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -139,10 +139,11 @@
         "href": "http://www.atsc.org/cms/standards/a72/A72-Part-1-2014.pdf",
         "date": "18 February 2014"
     },
+    "AX API": {
+        "aliasOf": "NSAccessibility"
+    },
     "AXAPI": {
-        "href": "https://developer.apple.com/reference/appkit/nsaccessibility-jku",
-        "title": "The Mac OS X Accessibility Protocol Mac OS 10.10",
-        "publisher": "Apple, Inc."
+        "aliasOf": "NSAccessibility"
     },
     "BBC-WP193": {
         "authors": [
@@ -1558,6 +1559,11 @@
         "title": "Navigator interface in HTML5",
         "status": "ED",
         "publisher": "W3C"
+    },
+    "NSAccessibility": {
+        "href": "https://developer.apple.com/documentation/appkit/nsaccessibility",
+        "title": "The NSAccessibility Protocol for macOS",
+        "publisher": "Apple, Inc."
     },
     "NTP": {
         "aliasOf": "RFC1305"

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -139,9 +139,6 @@
         "href": "http://www.atsc.org/cms/standards/a72/A72-Part-1-2014.pdf",
         "date": "18 February 2014"
     },
-    "AX API": {
-        "aliasOf": "NSAccessibility"
-    },
     "AXAPI": {
         "aliasOf": "NSAccessibility"
     },


### PR DESCRIPTION
* Create new "NSAccessibility" entry pointing to current documentation
  (The current "AXAPI" entry references old and largely deprecated API)

* Make "AXAPI" an alias for "NSAccessibility"