### PR TITLE
Add non-legacy MIDI 1.0 reference

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1477,6 +1477,14 @@
     "MEDIAQ": {
         "aliasOf": "css3-mediaqueries"
     },
+    "MIDI": {
+        "href": "https://www.midi.org/specifications/item/the-midi-1-0-specification",
+        "title": "The Complete MIDI 1.0 Detailed Specification",
+        "publisher": "The MIDI Manufacturers Association",
+        "version": "96.1",
+        "edition": "3",
+        "date": "2014"
+    },
     "MIME-ENC": {
         "aliasOf": "RFC2557"
     },


### PR DESCRIPTION
Up to date reference to the latest (2014) MIDI 1.0 specification, version 96.1, Third Edition