### PR TITLE
Add alias for SELECTORS-4.

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1997,6 +1997,9 @@
     "SELECTORS-LEVEL-3": {
         "aliasOf": "css3-selectors"
     },
+    "SELECTORS-4": {
+        "aliasOf": "selectors4"
+    },
     "SGML-XML": {
         "aliasOf": "NOTE-sgml-xml-19971215"
     },


### PR DESCRIPTION
This helps fix a bug where Bikeshed, which knows the spec as "selectors-4", doesn't de-dupe it with references to "selectors4".