### PR TITLE
Document where W3C/IETF import scripts are

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,6 @@
+# Auto-update scripts
+
+Here are the important files in this directory:
+
+* `rfc.js` merges IETF data
+* `rdf.js` merges W3C data


### PR DESCRIPTION
I couldn't find this myself, so I figured I would document it for others. `rdf.js` in particular isn't very well-named.