### PR TITLE
Update MMS13 URL

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1559,7 +1559,7 @@
     },
     "MMS13": {
         "date": "13 September 2011",
-        "href": "http://technical.openmobilealliance.org/Technical/release_program/mms_v1_3.aspx",
+        "href": "http://www.openmobilealliance.org/",
         "publisher": "Open Mobile Alliance",
         "status": "Approved Enabler Release",
         "title": "Multimedia Messaging Service 1.3"

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1559,7 +1559,7 @@
     },
     "MMS13": {
         "date": "13 September 2011",
-        "href": "http://www.openmobilealliance.org/",
+        "href": "http://www.openmobilealliance.org/release/MMS/",
         "publisher": "Open Mobile Alliance",
         "status": "Approved Enabler Release",
         "title": "Multimedia Messaging Service 1.3"


### PR DESCRIPTION
It is recommended that this out of date URL be updated to http://www.openmobilealliance.org/ , that is a stable URL.