### PR TITLE
Adding entries of INSPIRE and ISA specifications

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -3643,5 +3643,153 @@
             "https://www.w3.org/community/web-bluetooth/"
         ],
         "publisher": "W3C Web Bluetooth Community Group"
+    },
+    "inspire-md":{
+        "href":"https://inspire.ec.europa.eu/id/document/tg/metadata-iso19139",
+        "title":"Technical Guidance for the implementation of INSPIRE dataset and service metadata based on ISO/TS 19139:2007",
+        "rawDate":"2017-03-02",
+        "status":"Version 2.0.1",
+        "publisher":"European Commission",
+        "deliveredBy":[
+            "https://inspire.ec.europa.eu/inspire-maintenance-and-implementation/"
+        ],
+        "versions":{
+            "20170302":{
+                "href":"https://inspire.ec.europa.eu/id/document/tg/metadata-iso19139",
+                "title":"Technical Guidance for the implementation of INSPIRE dataset and service metadata based on ISO/TS 19139:2007",
+                "rawDate":"2017-03-02",
+                "status":"Version 2.0.1",
+                "publisher":"European Commission",
+                "deliveredBy":[
+                    "https://inspire.ec.europa.eu/inspire-maintenance-and-implementation/"
+                ]
+            },
+            "20131029":{
+                "href":"http://inspire.ec.europa.eu/documents/Metadata/MD_IR_and_ISO_20131029.pdf",
+                "title":"INSPIRE Metadata Implementing Rules: Technical Guidelines based on EN ISO 19115 and EN ISO 19119",
+                "rawDate":"2013-10-29",
+                "status":"Version 1.3",
+                "publisher":"European Commission",
+                "deliveredBy":[
+                    "https://inspire.ec.europa.eu/inspire-maintenance-and-implementation/"
+                ]
+            },
+            "20100616":{
+                "href":"http://inspire.ec.europa.eu/documents/Metadata/INSPIRE_MD_IR_and_ISO_v1_2_20100616.pdf",
+                "title":"INSPIRE Metadata Implementing Rules: Technical Guidelines based on EN ISO 19115 and EN ISO 19119",
+                "rawDate":"2010-06-16",
+                "status":"Version 1.2",
+                "publisher":"European Commission",
+                "deliveredBy":[
+                    "https://inspire.ec.europa.eu/inspire-maintenance-and-implementation/"
+                ]
+            },
+            "20090218":{
+                "href":"http://inspire.ec.europa.eu/reports/ImplementingRules/metadata/MD_IR_and_ISO_20090218.pdf",
+                "title":"INSPIRE Metadata Implementing Rules: Technical Guidelines based on EN ISO 19115 and EN ISO 19119",
+                "rawDate":"2009-02-18",
+                "status":"Version 1.1",
+                "publisher":"European Commission",
+                "deliveredBy":[
+                    "https://inspire.ec.europa.eu/inspire-maintenance-and-implementation/"
+                ]
+            },
+            "20081219":{
+                "href":"http://inspire.ec.europa.eu/reports/ImplementingRules/metadata/MD_IR_and_ISO_20081219.pdf",
+                "title":"INSPIRE Metadata Implementing Rules: Technical Guidelines based on EN ISO 19115 and EN ISO 19119",
+                "rawDate":"2008-12-19",
+                "status":"Version 1.0",
+                "publisher":"European Commission",
+                "deliveredBy":[
+                    "https://inspire.ec.europa.eu/inspire-maintenance-and-implementation/"
+                ]
+            }
+        }
+    },
+    "dcat-ap":{
+        "href":"https://joinup.ec.europa.eu/asset/dcat_application_profile/",
+        "title":"DCAT Application Profile for data portals in Europe",
+        "publisher":"European Commission",
+        "rawDate":"2017-02-24",
+        "status":"Version 1.1",
+        "deliveredBy":[
+            "https://joinup.ec.europa.eu/asset/dcat_application_profile/"
+        ],
+        "versions":{
+            "20170224":{
+                "href":"https://joinup.ec.europa.eu/asset/dcat_application_profile/asset_release/dcat-ap-v11",
+                "title":"DCAT Application Profile for data portals in Europe",
+                "rawDate":"2017-02-24",
+                "status":"Version 1.1",
+                "publisher":"European Commission",
+                "deliveredBy":[
+                    "https://joinup.ec.europa.eu/asset/dcat_application_profile/"
+                ]
+            },
+            "20140515":{
+                "href":"https://joinup.ec.europa.eu/catalogue/distribution/dcat-ap_final_v101pdf",
+                "title":"DCAT Application Profile for data portals in Europe",
+                "rawDate":"2014-04-15",
+                "status":"Version 1.01",
+                "publisher":"European Commission",
+                "deliveredBy":[
+                    "https://joinup.ec.europa.eu/asset/dcat_application_profile/"
+                ]
+            }
+        }
+    },
+    "geodcat-ap":{
+        "href":"https://joinup.ec.europa.eu/node/139283/",
+        "title":"GeoDCAT-AP: A geospatial extension for the DCAT application profile for data portals in Europe",
+        "rawDate":"2016-08-02",
+        "status":"Version 1.0.1",
+        "publisher":"European Commission",
+        "deliveredBy":[
+            "https://joinup.ec.europa.eu/node/139283/"
+        ],
+        "versions":{
+            "20160802":{
+                "href":"https://joinup.ec.europa.eu/asset/dcat_application_profile/asset_release/geodcat-ap-v101",
+                "title":"GeoDCAT-AP: A geospatial extension for the DCAT application profile for data portals in Europe",
+                "rawDate":"2016-08-02",
+                "status":"Version 1.0.1",
+                "publisher":"European Commission",
+                "deliveredBy":[
+                    "https://joinup.ec.europa.eu/node/139283/"
+                ]
+            },
+            "20151223":{
+                "href":"https://joinup.ec.europa.eu/asset/dcat_application_profile/asset_release/geodcat-ap-v10",
+                "title":"GeoDCAT-AP: A geospatial extension for the DCAT application profile for data portals in Europe",
+                "rawDate":"2015-12-23",
+                "status":"Version 1.0",
+                "publisher":"European Commission",
+                "deliveredBy":[
+                    "https://joinup.ec.europa.eu/node/139283/"
+                ]
+            }
+        }
+    },
+    "statdcat-ap":{
+        "href":"https://joinup.ec.europa.eu/asset/stat_dcat_application_profile/",
+        "title":"StatDCAT-AP – DCAT Application Profile for description of statistical datasets",
+        "rawDate":"2016-12-15",
+        "status":"Version 1.0.0",
+        "publisher":"European Commission",
+        "deliveredBy":[
+            "https://joinup.ec.europa.eu/asset/stat_dcat_application_profile/"
+        ],
+        "versions":{
+            "20161215":{
+                "href":"https://joinup.ec.europa.eu/asset/stat_dcat_application_profile/asset_release/statdcat-ap-v100",
+                "title":"StatDCAT-AP – DCAT Application Profile for description of statistical datasets",
+                "rawDate":"2016-12-15",
+                "status":"Version 1.0.0",
+                "publisher":"European Commission",
+                "deliveredBy":[
+                    "https://joinup.ec.europa.eu/asset/stat_dcat_application_profile/"
+                ]
+            }
+        }
     }
 }

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -3645,7 +3645,7 @@
         "publisher": "W3C Web Bluetooth Community Group"
     },
     "inspire-md":{
-        "href":"https://inspire.ec.europa.eu/id/document/tg/metadata-iso19139",
+        "href":"https://inspire.ec.europa.eu/file/1705/download?token=iSTwpRWd",
         "title":"Technical Guidance for the implementation of INSPIRE dataset and service metadata based on ISO/TS 19139:2007",
         "rawDate":"2017-03-02",
         "status":"Version 2.0.1",


### PR DESCRIPTION
The proposed entries concern two sets of specifications, developed in the framework of EU activities, and implemented across Europe:
* [INSPIRE](http://inspire.ec.europa.eu/) (Infrastructure for spatial information in Europe)
* [EU ISA Programme](https://ec.europa.eu/isa) (Interoperability solutions for public administrations, businesses and citizens)