### PR TITLE
Added specs referred to from W3C SDWWG and DXWG

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -3881,7 +3881,6 @@
         "href":"http://purl.org/vocommons/voaf",
         "title":"Vocabulary of a Friend (VOAF)",
         "rawDate":"2013-05-24",
-        "status":"Version 2.3",
         "publisher":"OKFN",
         "versions":{
             "20130524":{
@@ -3889,9 +3888,8 @@
                     "Bernard Vatant"
                 ],
                 "href":"http://lov.okfn.org/vocommons/voaf/v2.3/",
-                "title":"Vocabulary of a Friend (VOAF)",
+                "title":"Vocabulary of a Friend (VOAF). Version 2.3",
                 "rawDate":"2013-05-24",
-                "status":"Version 2.3",
                 "publisher":"OKFN"
             },
             "20130424":{
@@ -3899,9 +3897,8 @@
                     "Bernard Vatant"
                 ],
                 "href":"http://lov.okfn.org/vocommons/voaf/v2.2/",
-                "title":"Vocabulary of a Friend (VOAF)",
+                "title":"Vocabulary of a Friend (VOAF). Version 2.2",
                 "rawDate":"2013-04-24",
-                "status":"Version 2.2",
                 "publisher":"OKFN"
             },
             "20121015":{
@@ -3909,9 +3906,8 @@
                     "Bernard Vatant"
                 ],
                 "href":"http://lov.okfn.org/vocommons/voaf/v2.1/",
-                "title":"Vocabulary of a Friend (VOAF)",
+                "title":"Vocabulary of a Friend (VOAF). Version 2.1",
                 "rawDate":"2012-10-15",
-                "status":"Version 2.1",
                 "publisher":"OKFN"
             },
             "20120703":{
@@ -3919,9 +3915,8 @@
                     "Bernard Vatant"
                 ],
                 "href":"http://lov.okfn.org/vocommons/voaf/v2.0/",
-                "title":"Vocabulary of a Friend (VOAF)",
+                "title":"Vocabulary of a Friend (VOAF). Version 2.0",
                 "rawDate":"2012-07-03",
-                "status":"Version 2.0",
                 "publisher":"OKFN"
             },
             "20111116":{
@@ -3929,9 +3924,8 @@
                     "Bernard Vatant"
                 ],
                 "href":"http://lov.okfn.org/vocommons/voaf/v1.1/",
-                "title":"Vocabulary of a Friend (VOAF)",
+                "title":"Vocabulary of a Friend (VOAF). Version 1.1",
                 "rawDate":"2011-11-16",
-                "status":"Version 1.1",
                 "publisher":"Mondeca"
             },
             "20111103":{
@@ -3939,10 +3933,9 @@
                     "Bernard Vatant"
                 ],
                 "href":"http://lov.okfn.org/vocommons/voaf/v1.0/",
-                "title":"Vocabulary of a Friend (VOAF)",
-                "rawDate":"2011-11-03",
-                "status":"Version 1.0",
-                "publisher":"Mondeca"
+                "title":"Vocabulary of a Friend (VOAF). Version 1.0",
+                "publisher":"Mondeca",
+                "rawDate":"2011-11-03"
             }
         }
     },
@@ -3960,8 +3953,7 @@
         "href":"http://bibliographic-ontology.org/specification",
         "title":"Bibliographic Ontology Specification",
         "publisher":"Structured Dynamics LLC.",
-        "rawDate":"2016-05-11",
-        "status":"Revision 1.3"
+        "rawDate":"2016-05-11"
     },
     "datacite":{
         "authors":[
@@ -3974,85 +3966,78 @@
             "https://www.datacite.org/"
         ],
         "rawDate":"2016-09-16",
-        "status":"Version 4.0",
         "versions":{
             "20160916":{
                 "authors":[
                     "DataCite Metadata Working Group"
                 ],
                 "href":"https://schema.datacite.org/meta/kernel-4.0/",
-                "title":"DataCite Metadata Schema",
+                "title":"DataCite Metadata Schema 4.0",
                 "publisher":"DataCite e.V.",
                 "deliveredBy":[
                     "https://www.datacite.org/"
                 ],
-                "rawDate":"2016-09-16",
-                "status":"Version 4.0"
+                "rawDate":"2016-09-16"
             },
             "20141016":{
                 "authors":[
                     "DataCite Metadata Working Group"
                 ],
                 "href":"https://schema.datacite.org/meta/kernel-3.1/",
-                "title":"DataCite Metadata Schema",
+                "title":"DataCite Metadata Schema 3.1",
                 "publisher":"DataCite e.V.",
                 "deliveredBy":[
                     "https://www.datacite.org/"
                 ],
-                "rawDate":"2014-10-16",
-                "status":"Version 3.1"
+                "rawDate":"2014-10-16"
             },
             "20130724":{
                 "authors":[
                     "DataCite Metadata Working Group"
                 ],
                 "href":"https://schema.datacite.org/meta/kernel-3.0/",
-                "title":"DataCite Metadata Schema",
+                "title":"DataCite Metadata Schema 3.0",
                 "publisher":"DataCite e.V.",
                 "deliveredBy":[
                     "https://www.datacite.org/"
                 ],
-                "rawDate":"2013-07-24",
-                "status":"Version 3.0"
+                "rawDate":"2013-07-24"
             },
             "20110711":{
                 "authors":[
                     "DataCite Metadata Working Group"
                 ],
                 "href":"https://schema.datacite.org/meta/kernel-2.2/",
-                "title":"DataCite Metadata Schema",
+                "title":"DataCite Metadata Schema 2.2",
                 "publisher":"DataCite e.V.",
                 "deliveredBy":[
                     "https://www.datacite.org/"
                 ],
-                "rawDate":"2011-07-11",
-                "status":"Version 2.2"
+                "rawDate":"2011-07-11"
             },
             "20110328":{
                 "authors":[
                     "DataCite Metadata Working Group"
                 ],
                 "href":"https://schema.datacite.org/meta/kernel-2.1/",
-                "title":"DataCite Metadata Schema",
+                "title":"DataCite Metadata Schema 2.1",
                 "publisher":"DataCite e.V.",
                 "deliveredBy":[
                     "https://www.datacite.org/"
                 ],
-                "rawDate":"2011-03-28",
-                "status":"Version 2.1"
+                "rawDate":"2011-03-28"
             },
             "20110124":{
                 "authors":[
                     "DataCite Metadata Working Group"
                 ],
                 "href":"https://schema.datacite.org/meta/kernel-2.0/",
-                "title":"DataCite Metadata Schema",
+                "title":"DataCite Metadata Schema 2.0",
                 "publisher":"DataCite e.V.",
                 "deliveredBy":[
                     "https://www.datacite.org/"
                 ],
                 "rawDate":"2011-03-28",
-                "status":"Version 2.0",
                 "isRetired":true
             }
         }
@@ -4071,7 +4056,6 @@
             "http://www.openarchives.org/"
         ],
         "rawDate":"2015-01-08",
-        "status":"Version 2.0",
         "versions":{
             "20150108":{
                 "authors":[
@@ -4081,13 +4065,12 @@
                     "Simeon Warner"
                 ],
                 "href":"http://www.openarchives.org/OAI/2.0/openarchivesprotocol.htm",
-                "title":"The Open Archives Initiative Protocol for Metadata Harvesting",
+                "title":"The Open Archives Initiative Protocol for Metadata Harvesting. Version 2.0",
                 "publisher":"OAI",
                 "deliveredBy":[
                     "http://www.openarchives.org/"
                 ],
-                "rawDate":"2015-01-08",
-                "status":"Version 2.0"
+                "rawDate":"2015-01-08"
             },
             "20010620":{
                 "authors":[
@@ -4095,13 +4078,12 @@
                     "Herbert Van de Sompel"
                 ],
                 "href":"http://www.openarchives.org/OAI/1.1/openarchivesprotocol.htm",
-                "title":"The Open Archives Initiative Protocol for Metadata Harvesting",
+                "title":"The Open Archives Initiative Protocol for Metadata Harvesting. Version 1.1",
                 "publisher":"OAI",
                 "deliveredBy":[
                     "http://www.openarchives.org/"
                 ],
-                "rawDate":"2001-06-20",
-                "status":"Version 1.1"
+                "rawDate":"2001-06-20"
             },
             "20010424":{
                 "authors":[
@@ -4109,13 +4091,12 @@
                     "Carl Lagoze"
                 ],
                 "href":"http://www.openarchives.org/OAI/1.0/openarchivesprotocol.htm",
-                "title":"The Open Archives Initiative Protocol for Metadata Harvesting",
+                "title":"The Open Archives Initiative Protocol for Metadata Harvesting. Version 1.0",
                 "publisher":"OAI",
                 "deliveredBy":[
                     "http://www.openarchives.org/"
                 ],
-                "rawDate":"2001-04-24",
-                "status":"Version 1.0"
+                "rawDate":"2001-04-24"
             }
         }
     }    

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -3792,4 +3792,379 @@
         ],
         "publisher": "W3C Web Bluetooth Community Group"
     }
+
+    "w3c-basic-geo":{
+        "href":"https://www.w3.org/2003/01/geo/",
+        "title":"Basic Geo (WGS84 lat/long) Vocabulary",
+        "authors":[
+            "Dan Brickley"
+        ],
+        "publisher":"W3C Semantic Web Interest Group",
+        "rawDate":"2006-02-01"
+    },
+    "georss":{
+        "href":"https://www.w3.org/2005/Incubator/geo/XGR-geo/",
+        "title":"W3C Geospatial Vocabulary",
+        "authors":[
+            "Joshua Lieberman",
+            "Raj Singh",
+            "Chris Goad"
+        ],
+        "publisher":"W3C Geospatial Incubator Group",
+        "rawDate":"2007-10-23",
+        "status":"W3C Incubator Group Report"
+    },
+    "locn":{
+        "authors":[
+            "Andrea Perego",
+            "Michael Lutz"
+        ],
+        "href":"http://www.w3.org/ns/locn",
+        "title":"ISA Programme Location Core Vocabulary",
+        "rawDate":"2015-03-23",
+        "status":"Second version in w3.org/ns space",
+        "publisher":"European Commission",
+        "deliveredBy":[
+            "https://joinup.ec.europa.eu/asset/core_location"
+        ],
+        "versions":{
+            "20131125":{
+                "authors":[
+                    "Andrea Perego",
+                    "Michael Lutz",
+                    "Phil Archer"
+                ],
+                "href":"https://www.w3.org/2015/04/locn",
+                "title":"ISA Programme Location Core Vocabulary",
+                "rawDate":"2013-11-25",
+                "status":"First version in w3.org/ns space",
+                "publisher":"European Commission",
+                "deliveredBy":[
+                    "https://joinup.ec.europa.eu/asset/core_location/"
+                ]
+            }
+        }
+    },
+    "vann":{
+        "authors":[
+            "Ian Davis"
+        ],
+        "href":"http://purl.org/vocab/vann",
+        "title":"VANN: A vocabulary for annotating vocabulary descriptions",
+        "rawDate":"2010-06-07",
+        "publisher":"Vocab.org",
+        "versions":{
+            "20100607":{
+                "authors":[
+                    "Ian Davis"
+                ],
+                "href":"http://purl.org/vocab/vann/vann-vocab-20050401",
+                "title":"VANN: A vocabulary for annotating vocabulary descriptions",
+                "rawDate":"2010-06-07",
+                "publisher":"Vocab.org",
+                "obsoletes":[
+                    "vann-20040305"
+                ]
+            },
+            "20040305":{
+                "authors":[
+                    "Ian Davis"
+                ],
+                "href":"http://purl.org/vocab/vann/vann-vocab-20030405",
+                "title":"VANN: A vocabulary for annotating vocabulary descriptions",
+                "rawDate":"2004-03-05",
+                "publisher":"Vocab.org",
+                "obsoletedBy":[
+                    "vann-20100607"
+                ]
+            }
+        }
+    },
+    "voaf":{
+        "authors":[
+            "Bernard Vatant"
+        ],
+        "href":"http://purl.org/vocommons/voaf",
+        "title":"Vocabulary of a Friend (VOAF)",
+        "rawDate":"2013-05-24",
+        "status":"Version 2.3",
+        "publisher":"OKFN",
+        "versions":{
+            "20130524":{
+                "authors":[
+                    "Bernard Vatant"
+                ],
+                "href":"http://lov.okfn.org/vocommons/voaf/v2.3/",
+                "title":"Vocabulary of a Friend (VOAF)",
+                "rawDate":"2013-05-24",
+                "status":"Version 2.3",
+                "publisher":"OKFN",
+                "obsoletes":[
+                    "voaf-20130424"
+                ]
+            },
+            "20130424":{
+                "authors":[
+                    "Bernard Vatant"
+                ],
+                "href":"http://lov.okfn.org/vocommons/voaf/v2.2/",
+                "title":"Vocabulary of a Friend (VOAF)",
+                "rawDate":"2013-04-24",
+                "status":"Version 2.2",
+                "publisher":"OKFN",
+                "obsoletes":[
+                    "voaf-20121015"
+                ]
+            },
+            "20121015":{
+                "authors":[
+                    "Bernard Vatant"
+                ],
+                "href":"http://lov.okfn.org/vocommons/voaf/v2.1/",
+                "title":"Vocabulary of a Friend (VOAF)",
+                "rawDate":"2012-10-15",
+                "status":"Version 2.1",
+                "publisher":"OKFN",
+                "obsoletes":[
+                    "voaf-20120703"
+                ]
+            },
+            "20120703":{
+                "authors":[
+                    "Bernard Vatant"
+                ],
+                "href":"http://lov.okfn.org/vocommons/voaf/v2.0/",
+                "title":"Vocabulary of a Friend (VOAF)",
+                "rawDate":"2012-07-03",
+                "status":"Version 2.0",
+                "publisher":"OKFN",
+                "obsoletes":[
+                    "voaf-20111116"
+                ]
+            },
+            "20111116":{
+                "authors":[
+                    "Bernard Vatant"
+                ],
+                "href":"http://lov.okfn.org/vocommons/voaf/v1.1/",
+                "title":"Vocabulary of a Friend (VOAF)",
+                "rawDate":"2011-11-16",
+                "status":"Version 1.1",
+                "publisher":"Mondeca",
+                "obsoletes":[
+                    "voaf-20111103"
+                ]
+            },
+            "20111103":{
+                "authors":[
+                    "Bernard Vatant"
+                ],
+                "href":"http://lov.okfn.org/vocommons/voaf/v1.0/",
+                "title":"Vocabulary of a Friend (VOAF)",
+                "rawDate":"2011-11-03",
+                "status":"Version 1.0",
+                "publisher":"Mondeca"
+            }
+        }
+    },
+    "prism":{
+        "href":"http://www.prismstandard.org/specifications/3.0/PRISM_Basic_Metadata_3.0.htm",
+        "title":"Publishing Requirements for Industry Standard Metadata, Version 3.0. PRISM Basic Metadata Specification",
+        "publisher":"International Digital Enterprise Alliance, Inc.",
+        "rawDate":"2012-10-08"
+    },
+    "bibo":{
+        "authors":[
+            "Bruce D'Arcus",
+            "Frédérick Giasson"
+        ],
+        "href":"http://bibliographic-ontology.org/specification",
+        "title":"Bibliographic Ontology Specification",
+        "publisher":"Structured Dynamics LLC.",
+        "rawDate":"2016-05-11",
+        "status":"Revision 1.3"
+    },
+    "datacite":{
+        "authors":[
+            "DataCite Metadata Working Group"
+        ],
+        "href":"https://schema.datacite.org/",
+        "title":"DataCite Metadata Schema",
+        "publisher":"DataCite e.V.",
+        "deliveredBy":[
+            "https://www.datacite.org/"
+        ],
+        "rawDate":"2016-09-16",
+        "status":"Version 4.0",
+        "versions":{
+            "20160916":{
+                "authors":[
+                    "DataCite Metadata Working Group"
+                ],
+                "href":"https://schema.datacite.org/meta/kernel-4.0/",
+                "title":"DataCite Metadata Schema",
+                "publisher":"DataCite e.V.",
+                "deliveredBy":[
+                    "https://www.datacite.org/"
+                ],
+                "rawDate":"2016-09-16",
+                "status":"Version 4.0",
+                "obsoletes":[
+                    "datacite-20141016"
+                ]
+            },
+            "20141016":{
+                "authors":[
+                    "DataCite Metadata Working Group"
+                ],
+                "href":"https://schema.datacite.org/meta/kernel-3.1/",
+                "title":"DataCite Metadata Schema",
+                "publisher":"DataCite e.V.",
+                "deliveredBy":[
+                    "https://www.datacite.org/"
+                ],
+                "rawDate":"2014-10-16",
+                "status":"Version 3.1",
+                "obsoletes":[
+                    "datacite-20130724"
+                ]
+            },
+            "20130724":{
+                "authors":[
+                    "DataCite Metadata Working Group"
+                ],
+                "href":"https://schema.datacite.org/meta/kernel-3.0/",
+                "title":"DataCite Metadata Schema",
+                "publisher":"DataCite e.V.",
+                "deliveredBy":[
+                    "https://www.datacite.org/"
+                ],
+                "rawDate":"2013-07-24",
+                "status":"Version 3.0",
+                "obsoletes":[
+                    "datacite-20110711"
+                ]
+            },
+            "20110711":{
+                "authors":[
+                    "DataCite Metadata Working Group"
+                ],
+                "href":"https://schema.datacite.org/meta/kernel-2.2/",
+                "title":"DataCite Metadata Schema",
+                "publisher":"DataCite e.V.",
+                "deliveredBy":[
+                    "https://www.datacite.org/"
+                ],
+                "rawDate":"2011-07-11",
+                "status":"Version 2.2",
+                "obsoletes":[
+                    "datacite-20110328"
+                ]
+            },
+            "20110328":{
+                "authors":[
+                    "DataCite Metadata Working Group"
+                ],
+                "href":"https://schema.datacite.org/meta/kernel-2.1/",
+                "title":"DataCite Metadata Schema",
+                "publisher":"DataCite e.V.",
+                "deliveredBy":[
+                    "https://www.datacite.org/"
+                ],
+                "rawDate":"2011-03-28",
+                "status":"Version 2.1",
+                "obsoletes":[
+                    "datacite-20110124"
+                ]
+            },
+            "20110124":{
+                "authors":[
+                    "DataCite Metadata Working Group"
+                ],
+                "href":"https://schema.datacite.org/meta/kernel-2.0/",
+                "title":"DataCite Metadata Schema",
+                "publisher":"DataCite e.V.",
+                "deliveredBy":[
+                    "https://www.datacite.org/"
+                ],
+                "rawDate":"2011-03-28",
+                "status":"Version 2.0",
+                "isRetired":true
+            }
+        }
+    },
+    "oai-pmh":{
+        "authors":[
+            "Carl Lagoze",
+            "Herbert Van de Sompel",
+            "Michael Nelson",
+            "Simeon Warner"
+        ],
+        "href":"http://www.openarchives.org/OAI/openarchivesprotocol.html",
+        "title":"The Open Archives Initiative Protocol for Metadata Harvesting",
+        "publisher":"OAI",
+        "deliveredBy":[
+            "http://www.openarchives.org/"
+        ],
+        "rawDate":"2015-01-08",
+        "status":"Version 2.0",
+        "versions":{
+            "20150108":{
+                "authors":[
+                    "Carl Lagoze",
+                    "Herbert Van de Sompel",
+                    "Michael Nelson",
+                    "Simeon Warner"
+                ],
+                "href":"http://www.openarchives.org/OAI/2.0/openarchivesprotocol.htm",
+                "title":"The Open Archives Initiative Protocol for Metadata Harvesting",
+                "publisher":"OAI",
+                "deliveredBy":[
+                    "http://www.openarchives.org/"
+                ],
+                "rawDate":"2015-01-08",
+                "status":"Version 2.0",
+                "obsoletes":[
+                    "oai-pmh-20010620"
+                ]
+            },
+            "20010620":{
+                "authors":[
+                    "Carl Lagoze",
+                    "Herbert Van de Sompel"
+                ],
+                "href":"http://www.openarchives.org/OAI/1.1/openarchivesprotocol.htm",
+                "title":"The Open Archives Initiative Protocol for Metadata Harvesting",
+                "publisher":"OAI",
+                "deliveredBy":[
+                    "http://www.openarchives.org/"
+                ],
+                "rawDate":"2001-06-20",
+                "status":"Version 1.1",
+                "obsoletes":[
+                    "oai-pmh-20010424"
+                ],
+                "obsoletedBy":[
+                    "oai-pmh-20150108"
+                ]
+            },
+            "20010424":{
+                "authors":[
+                    "Herbert Van de Sompel",
+                    "Carl Lagoze"
+                ],
+                "href":"http://www.openarchives.org/OAI/1.0/openarchivesprotocol.htm",
+                "title":"The Open Archives Initiative Protocol for Metadata Harvesting",
+                "publisher":"OAI",
+                "deliveredBy":[
+                    "http://www.openarchives.org/"
+                ],
+                "rawDate":"2001-04-24",
+                "status":"Version 1.0",
+                "obsoletedBy":[
+                    "oai-pmh-20150108"
+                ]
+            }
+        }
+    }    
 }

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -3863,7 +3863,7 @@
                 "rawDate":"2010-06-07",
                 "publisher":"Vocab.org",
                 "obsoletes":[
-                    "vann-20040305"
+                    "20040305"
                 ]
             },
             "20040305":{
@@ -3875,7 +3875,7 @@
                 "rawDate":"2004-03-05",
                 "publisher":"Vocab.org",
                 "obsoletedBy":[
-                    "vann-20100607"
+                    "20100607"
                 ]
             }
         }
@@ -3900,7 +3900,7 @@
                 "status":"Version 2.3",
                 "publisher":"OKFN",
                 "obsoletes":[
-                    "voaf-20130424"
+                    "20130424"
                 ]
             },
             "20130424":{
@@ -3913,7 +3913,7 @@
                 "status":"Version 2.2",
                 "publisher":"OKFN",
                 "obsoletes":[
-                    "voaf-20121015"
+                    "20121015"
                 ]
             },
             "20121015":{
@@ -3926,7 +3926,7 @@
                 "status":"Version 2.1",
                 "publisher":"OKFN",
                 "obsoletes":[
-                    "voaf-20120703"
+                    "20120703"
                 ]
             },
             "20120703":{
@@ -3939,7 +3939,7 @@
                 "status":"Version 2.0",
                 "publisher":"OKFN",
                 "obsoletes":[
-                    "voaf-20111116"
+                    "20111116"
                 ]
             },
             "20111116":{
@@ -3952,7 +3952,7 @@
                 "status":"Version 1.1",
                 "publisher":"Mondeca",
                 "obsoletes":[
-                    "voaf-20111103"
+                    "20111103"
                 ]
             },
             "20111103":{
@@ -4010,7 +4010,7 @@
                 "rawDate":"2016-09-16",
                 "status":"Version 4.0",
                 "obsoletes":[
-                    "datacite-20141016"
+                    "20141016"
                 ]
             },
             "20141016":{
@@ -4026,7 +4026,7 @@
                 "rawDate":"2014-10-16",
                 "status":"Version 3.1",
                 "obsoletes":[
-                    "datacite-20130724"
+                    "20130724"
                 ]
             },
             "20130724":{
@@ -4042,7 +4042,7 @@
                 "rawDate":"2013-07-24",
                 "status":"Version 3.0",
                 "obsoletes":[
-                    "datacite-20110711"
+                    "20110711"
                 ]
             },
             "20110711":{
@@ -4058,7 +4058,7 @@
                 "rawDate":"2011-07-11",
                 "status":"Version 2.2",
                 "obsoletes":[
-                    "datacite-20110328"
+                    "20110328"
                 ]
             },
             "20110328":{
@@ -4074,7 +4074,7 @@
                 "rawDate":"2011-03-28",
                 "status":"Version 2.1",
                 "obsoletes":[
-                    "datacite-20110124"
+                    "20110124"
                 ]
             },
             "20110124":{
@@ -4125,7 +4125,7 @@
                 "rawDate":"2015-01-08",
                 "status":"Version 2.0",
                 "obsoletes":[
-                    "oai-pmh-20010620"
+                    "20010620"
                 ]
             },
             "20010620":{
@@ -4142,10 +4142,10 @@
                 "rawDate":"2001-06-20",
                 "status":"Version 1.1",
                 "obsoletes":[
-                    "oai-pmh-20010424"
+                    "20010424"
                 ],
                 "obsoletedBy":[
-                    "oai-pmh-20150108"
+                    "20150108"
                 ]
             },
             "20010424":{
@@ -4162,7 +4162,7 @@
                 "rawDate":"2001-04-24",
                 "status":"Version 1.0",
                 "obsoletedBy":[
-                    "oai-pmh-20150108"
+                    "20150108"
                 ]
             }
         }

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -3861,10 +3861,7 @@
                 "href":"http://purl.org/vocab/vann/vann-vocab-20050401",
                 "title":"VANN: A vocabulary for annotating vocabulary descriptions",
                 "rawDate":"2010-06-07",
-                "publisher":"Vocab.org",
-                "obsoletes":[
-                    "20040305"
-                ]
+                "publisher":"Vocab.org"
             },
             "20040305":{
                 "authors":[
@@ -3873,10 +3870,7 @@
                 "href":"http://purl.org/vocab/vann/vann-vocab-20030405",
                 "title":"VANN: A vocabulary for annotating vocabulary descriptions",
                 "rawDate":"2004-03-05",
-                "publisher":"Vocab.org",
-                "obsoletedBy":[
-                    "20100607"
-                ]
+                "publisher":"Vocab.org"
             }
         }
     },
@@ -3898,10 +3892,7 @@
                 "title":"Vocabulary of a Friend (VOAF)",
                 "rawDate":"2013-05-24",
                 "status":"Version 2.3",
-                "publisher":"OKFN",
-                "obsoletes":[
-                    "20130424"
-                ]
+                "publisher":"OKFN"
             },
             "20130424":{
                 "authors":[
@@ -3911,10 +3902,7 @@
                 "title":"Vocabulary of a Friend (VOAF)",
                 "rawDate":"2013-04-24",
                 "status":"Version 2.2",
-                "publisher":"OKFN",
-                "obsoletes":[
-                    "20121015"
-                ]
+                "publisher":"OKFN"
             },
             "20121015":{
                 "authors":[
@@ -3924,10 +3912,7 @@
                 "title":"Vocabulary of a Friend (VOAF)",
                 "rawDate":"2012-10-15",
                 "status":"Version 2.1",
-                "publisher":"OKFN",
-                "obsoletes":[
-                    "20120703"
-                ]
+                "publisher":"OKFN"
             },
             "20120703":{
                 "authors":[
@@ -3937,10 +3922,7 @@
                 "title":"Vocabulary of a Friend (VOAF)",
                 "rawDate":"2012-07-03",
                 "status":"Version 2.0",
-                "publisher":"OKFN",
-                "obsoletes":[
-                    "20111116"
-                ]
+                "publisher":"OKFN"
             },
             "20111116":{
                 "authors":[
@@ -3950,10 +3932,7 @@
                 "title":"Vocabulary of a Friend (VOAF)",
                 "rawDate":"2011-11-16",
                 "status":"Version 1.1",
-                "publisher":"Mondeca",
-                "obsoletes":[
-                    "20111103"
-                ]
+                "publisher":"Mondeca"
             },
             "20111103":{
                 "authors":[
@@ -4008,10 +3987,7 @@
                     "https://www.datacite.org/"
                 ],
                 "rawDate":"2016-09-16",
-                "status":"Version 4.0",
-                "obsoletes":[
-                    "20141016"
-                ]
+                "status":"Version 4.0"
             },
             "20141016":{
                 "authors":[
@@ -4024,10 +4000,7 @@
                     "https://www.datacite.org/"
                 ],
                 "rawDate":"2014-10-16",
-                "status":"Version 3.1",
-                "obsoletes":[
-                    "20130724"
-                ]
+                "status":"Version 3.1"
             },
             "20130724":{
                 "authors":[
@@ -4040,10 +4013,7 @@
                     "https://www.datacite.org/"
                 ],
                 "rawDate":"2013-07-24",
-                "status":"Version 3.0",
-                "obsoletes":[
-                    "20110711"
-                ]
+                "status":"Version 3.0"
             },
             "20110711":{
                 "authors":[
@@ -4056,10 +4026,7 @@
                     "https://www.datacite.org/"
                 ],
                 "rawDate":"2011-07-11",
-                "status":"Version 2.2",
-                "obsoletes":[
-                    "20110328"
-                ]
+                "status":"Version 2.2"
             },
             "20110328":{
                 "authors":[
@@ -4072,10 +4039,7 @@
                     "https://www.datacite.org/"
                 ],
                 "rawDate":"2011-03-28",
-                "status":"Version 2.1",
-                "obsoletes":[
-                    "20110124"
-                ]
+                "status":"Version 2.1"
             },
             "20110124":{
                 "authors":[
@@ -4123,10 +4087,7 @@
                     "http://www.openarchives.org/"
                 ],
                 "rawDate":"2015-01-08",
-                "status":"Version 2.0",
-                "obsoletes":[
-                    "20010620"
-                ]
+                "status":"Version 2.0"
             },
             "20010620":{
                 "authors":[
@@ -4140,13 +4101,7 @@
                     "http://www.openarchives.org/"
                 ],
                 "rawDate":"2001-06-20",
-                "status":"Version 1.1",
-                "obsoletes":[
-                    "20010424"
-                ],
-                "obsoletedBy":[
-                    "20150108"
-                ]
+                "status":"Version 1.1"
             },
             "20010424":{
                 "authors":[
@@ -4160,10 +4115,7 @@
                     "http://www.openarchives.org/"
                 ],
                 "rawDate":"2001-04-24",
-                "status":"Version 1.0",
-                "obsoletedBy":[
-                    "20150108"
-                ]
+                "status":"Version 1.0"
             }
         }
     }    

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -3791,7 +3791,7 @@
             "https://www.w3.org/community/web-bluetooth/"
         ],
         "publisher": "W3C Web Bluetooth Community Group"
-    }
+    },
 
     "w3c-basic-geo":{
         "href":"https://www.w3.org/2003/01/geo/",


### PR DESCRIPTION
Added the following entries referred to from the TRs of the [W3C/OGC Spatial Data on the Web WG](/w3c/sdw/) & the [W3C Dataset Exchange WG](/w3c/dxwg/):

* [W3C Basic Geo (WGS84 lat/long) Vocabulary](https://www.w3.org/2003/01/geo/) - key [`w3c-basic-geo`](https://api.specref.org/bibrefs?refs=w3c-basic-geo)
* [W3C Geospatial Vocabulary](https://www.w3.org/2005/Incubator/geo/XGR-geo/) - key [`georss`](https://api.specref.org/bibrefs?refs=georss)
* [ISA Programme Location Core Vocabulary](http://www.w3.org/ns/locn) - key [`locn`](https://api.specref.org/bibrefs?refs=locn)
* [VANN: A vocabulary for annotating vocabulary descriptions](http://purl.org/vocab/vann) - key [`vann`](https://api.specref.org/bibrefs?refs=vann) 
* [Vocabulary of a Friend (VOAF)](http://purl.org/vocommons/voaf) - key [`voaf`](https://api.specref.org/bibrefs?refs=voaf) 
* [PRISM Basic Metadata Specification](http://www.prismstandard.org/specifications/3.0/PRISM_Basic_Metadata_3.0.htm) - key [`prism`](https://api.specref.org/bibrefs?refs=prism)
* [Bibliographic Ontology](http://bibliographic-ontology.org/specification) - key [`bibo`](https://api.specref.org/bibrefs?refs=bibo)
* [DataCite Metadata Schema](https://schema.datacite.org/) - key [`datacite`](https://api.specref.org/bibrefs?refs=datacite)
* [Open Archives Initiative Protocol for Metadata Harvesting](http://www.openarchives.org/OAI/openarchivesprotocol.html) - key [`oai-pmh`](https://api.specref.org/bibrefs?refs=oai-pmh)
