### PR TITLE
Delete whatwg/mediasession reference

### DIFF
--- a/refs/whatwg.json
+++ b/refs/whatwg.json
@@ -149,13 +149,6 @@
         "publisher": "WHATWG",
         "source": "https://resources.whatwg.org/biblio.json"
     },
-    "MEDIASESSION": {
-        "href": "https://mediasession.spec.whatwg.org/",
-        "title": "Media Session Standard",
-        "publisher": "WHATWG",
-        "status": "Living Standard",
-        "source": "https://resources.whatwg.org/biblio.json"
-    },
     "MIMESNIFF": {
         "authors": [
             "Gordon P. Hemsley"

--- a/refs/wicg.json
+++ b/refs/wicg.json
@@ -6,6 +6,13 @@
         "publisher": "WICG",
         "source": "https://wicg.github.io/admin/biblio.json"
     },
+    "MEDIASESSION": {
+        "href": "https://wicg.github.io/mediasession/",
+        "title": "Media Session",
+        "status": "Living Standard",
+        "publisher": "WICG",
+        "source": "https://wicg.github.io/admin/biblio.json"
+    },
     "WEB-BACKGROUND-SYNC": {
         "href": "https://wicg.github.io/BackgroundSync/spec/",
         "title": "Web Background Synchronization specification draft",
@@ -24,11 +31,7 @@
         "aliasOf": "FEATURE-POLICY"
     },
     "WICG-MEDIASESSION": {
-        "href": "https://wicg.github.io/mediasession/",
-        "title": "Media Session",
-        "status": "Living Standard",
-        "publisher": "WICG",
-        "source": "https://wicg.github.io/admin/biblio.json"
+        "aliasOf": "MEDIASESSION"
     },
     "WICG-WEB-BACKGROUND-SYNC": {
         "aliasOf": "WEB-BACKGROUND-SYNC"


### PR DESCRIPTION
It's not listed in https://resources.whatwg.org/biblio.json and isn't being removed automatically.