### PR TITLE
Fix titles of BackgroundSync and WebUSB

### DIFF
--- a/refs/wicg.json
+++ b/refs/wicg.json
@@ -15,14 +15,14 @@
     },
     "WEB-BACKGROUND-SYNC": {
         "href": "https://wicg.github.io/BackgroundSync/spec/",
-        "title": "Web Background Synchronization specification draft",
+        "title": "Web Background Synchronization",
         "status": "Living Standard",
         "publisher": "WICG",
         "source": "https://wicg.github.io/admin/biblio.json"
     },
     "WEBUSB": {
         "href": "https://wicg.github.io/webusb/",
-        "title": "WebUSB API specification draft",
+        "title": "WebUSB API",
         "status": "Living Standard",
         "publisher": "WICG",
         "source": "https://wicg.github.io/admin/biblio.json"


### PR DESCRIPTION
The documents themselves don't have "specification draft" it in the titles.