### PR TITLE
Connect the EDs for a bunch of css3-* specs

### DIFF
--- a/refs/w3c.json
+++ b/refs/w3c.json
@@ -21442,7 +21442,8 @@
             "https://www.w3.org/Style/CSS/members"
         ],
         "rawDate": "2013-02-19",
-        "source": "https://www.w3.org/2002/01/tr-automation/tr.rdf"
+        "source": "https://www.w3.org/2002/01/tr-automation/tr.rdf",
+        "edDraft": "https://drafts.csswg.org/css-animations-1/"
     },
     "css3-background": {
         "authors": [
@@ -21791,7 +21792,8 @@
             }
         },
         "rawDate": "2013-04-04",
-        "source": "https://www.w3.org/2002/01/tr-automation/tr.rdf"
+        "source": "https://www.w3.org/2002/01/tr-automation/tr.rdf",
+        "edDraft": "https://drafts.csswg.org/css-conditional-3/"
     },
     "css3-content": {
         "aliasOf": "css-content-3"
@@ -22282,7 +22284,8 @@
                 ],
                 "source": "https://www.w3.org/2002/01/tr-automation/tr.rdf"
             }
-        }
+        },
+        "edDraft": "https://drafts.csswg.org/css-multicol-1/"
     },
     "css3-namespace": {
         "aliasOf": "css-namespaces-3"
@@ -22357,7 +22360,8 @@
             }
         },
         "rawDate": "2013-03-14",
-        "source": "https://www.w3.org/2002/01/tr-automation/tr.rdf"
+        "source": "https://www.w3.org/2002/01/tr-automation/tr.rdf",
+        "edDraft": "https://drafts.csswg.org/css-page-3/"
     },
     "css3-positioning": {
         "aliasOf": "css-position-3"
@@ -22607,7 +22611,8 @@
         ],
         "hasErrata": "https://www.w3.org/Style/2011/REC-css3-selectors-20110929-errata.html",
         "rawDate": "2011-09-29",
-        "source": "https://www.w3.org/2002/01/tr-automation/tr.rdf"
+        "source": "https://www.w3.org/2002/01/tr-automation/tr.rdf",
+        "edDraft": "https://drafts.csswg.org/selectors-3/"
     },
     "css3-sizing": {
         "aliasOf": "css-sizing-3"
@@ -22670,7 +22675,8 @@
             }
         },
         "rawDate": "2012-03-20",
-        "source": "https://www.w3.org/2002/01/tr-automation/tr.rdf"
+        "source": "https://www.w3.org/2002/01/tr-automation/tr.rdf",
+        "edDraft": "https://drafts.csswg.org/css-speech-1/"
     },
     "css3-syntax": {
         "aliasOf": "css-syntax-3"


### PR DESCRIPTION
Versioned links are used to be pedantically correct.