### PR TITLE
Fix the ED links for Encrypted Media and Touch Events

### DIFF
--- a/overwrites/w3c.json
+++ b/overwrites/w3c.json
@@ -15,7 +15,7 @@
         "edDraft": { "replaceWith": "https://w3c.github.io/ServiceWorker/" }
     },
     "touch-events": {
-        "edDraft": { "replaceWith": "https://w3c.github.io/uievents/" }
+        "edDraft": { "replaceWith": "https://w3c.github.io/touch-events/" }
     },
     "uievents": {
         "edDraft": { "replaceWith": "https://w3c.github.io/uievents/" }

--- a/overwrites/w3c.json
+++ b/overwrites/w3c.json
@@ -8,8 +8,14 @@
     "WebCryptoAPI": {
         "edDraft": { "replaceWith": "https://w3c.github.io/webcrypto/Overview.html" }
     },
+    "encrypted-media": {
+        "edDraft": { "replaceWith": "https://w3c.github.io/encrypted-media/" }
+    },
     "service-workers-1": {
         "edDraft": { "replaceWith": "https://w3c.github.io/ServiceWorker/" }
+    },
+    "touch-events": {
+        "edDraft": { "replaceWith": "https://w3c.github.io/uievents/" }
     },
     "uievents": {
         "edDraft": { "replaceWith": "https://w3c.github.io/uievents/" }


### PR DESCRIPTION
These are stale in https://www.w3.org/2002/01/tr-automation/tr.rdf