### PR TITLE
Prefer tools.ietf.org to datatracker.ietf.org for rtcweb documents

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1906,7 +1906,7 @@
             "M. Thomson"
         ],
         "date": "23 July 2014",
-        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-alpn",
+        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-alpn",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Application Layer Protocol Negotiation for Web Real-Time Communications"
@@ -1919,7 +1919,7 @@
             "Dan Burnett"
         ],
         "date": "4 July 2014",
-        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-constraints-registry",
+        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-constraints-registry",
         "publisher": "IETF",
         "status": "Internet Draft (work in progress)",
         "title": "IANA Registry for RTCWeb Constrainable Properties"
@@ -1931,7 +1931,7 @@
             "M. Tuexen"
         ],
         "date": "14 October 2015",
-        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-data-channel",
+        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-data-channel",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "RTCWeb Data Channels"
@@ -1943,7 +1943,7 @@
             "M. Tuexen"
         ],
         "date": "14 October 2015",
-        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-data-protocol",
+        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-data-protocol",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "RTCWeb Data Channel Protocol"
@@ -1954,7 +1954,7 @@
             "Justin Uberti"
         ],
         "date": "20 March 2016",
-        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-ip-handling",
+        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-ip-handling",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "WebRTC IP Address Handling Recommendations"
@@ -1965,7 +1965,7 @@
             "Cullen Jennings"
         ],
         "date": "22 October 2013",
-        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-jsep",
+        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-jsep",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Javascript Session Establishment Protocol"
@@ -1975,7 +1975,7 @@
             "H. Alvestrand"
         ],
         "date": "14 February 2014",
-        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-overview",
+        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-overview",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Overview: Real Time Protocols for Brower-based Applications"
@@ -1987,7 +1987,7 @@
             "J. Ott"
         ],
         "date": "17 March 2016",
-        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-rtp-usage",
+        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-rtp-usage",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Web Real-Time Communication (WebRTC): Media Transport and Use of RTP"
@@ -1997,7 +1997,7 @@
             "Eric Rescorla"
         ],
         "date": "22 January 2014",
-        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-security",
+        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-security",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Security Considerations for WebRTC"
@@ -2007,7 +2007,7 @@
             "Eric Rescorla"
         ],
         "date": "10 December 2016",
-        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-security-arch",
+        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-security-arch",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "WebRTC Security Architecture"
@@ -2017,7 +2017,7 @@
             "H. Alvestrand"
         ],
         "date": "31 October 2016",
-        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-transports",
+        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-transports",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Transports for RTCWEB"
@@ -2060,7 +2060,7 @@
             "G. Camarillo"
         ],
         "date": "20 March 2017",
-        "href": " https://tools.ietf.org/html/draft-ietf-mmusic-sctp-sdp",
+        "href": "https://tools.ietf.org/html/draft-ietf-mmusic-sctp-sdp",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Session Description Protocol (SDP) Offer/Answer Procedures For Stream Control Transmission Protocol (SCTP) over Datagram Transport Layer Security (DTLS) Transport"
@@ -2188,7 +2188,7 @@
             "P. Matthews"
         ],
         "date": "16 February 2017",
-        "href": " https://tools.ietf.org/html/draft-ietf-tram-stunbis",
+        "href": "https://tools.ietf.org/html/draft-ietf-tram-stunbis",
         "publisher": "IETF",
         "status": "Internet Draft (work in progress)",
         "title": "Session Traversal Utilities for NAT (STUN)"
@@ -2272,7 +2272,7 @@
             "J. Polk"
         ],
         "date": "22 August 2016",
-        "href": " https://tools.ietf.org/html/draft-ietf-tsvwg-rtcweb-qos",
+        "href": "https://tools.ietf.org/html/draft-ietf-tsvwg-rtcweb-qos",
         "publisher": "IETF",
         "status": "Internet Draft (work in progress)",
         "title": "DSCP Packet Markings for WebRTC QoS"

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -219,7 +219,7 @@
             "C. Jennings"
         ],
         "date": "31 August 2017",
-        "href": "https://datatracker.ietf.org/doc/draft-ietf-mmusic-sdp-bundle-negotiation/",
+        "href": " https://tools.ietf.org/html/draft-ietf-mmusic-sdp-bundle-negotiation",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Negotiating Media Multiplexing Using the Session Description Protocol (SDP)"
@@ -1906,7 +1906,7 @@
             "M. Thomson"
         ],
         "date": "23 July 2014",
-        "href": "https://datatracker.ietf.org/doc/draft-ietf-rtcweb-alpn/",
+        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-alpn",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Application Layer Protocol Negotiation for Web Real-Time Communications"
@@ -1919,7 +1919,7 @@
             "Dan Burnett"
         ],
         "date": "4 July 2014",
-        "href": "https://datatracker.ietf.org/doc/draft-ietf-rtcweb-constraints-registry/",
+        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-constraints-registry",
         "publisher": "IETF",
         "status": "Internet Draft (work in progress)",
         "title": "IANA Registry for RTCWeb Constrainable Properties"
@@ -1931,7 +1931,7 @@
             "M. Tuexen"
         ],
         "date": "14 October 2015",
-        "href": "https://datatracker.ietf.org/doc/draft-ietf-rtcweb-data-channel/",
+        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-data-channel",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "RTCWeb Data Channels"
@@ -1943,7 +1943,7 @@
             "M. Tuexen"
         ],
         "date": "14 October 2015",
-        "href": "https://datatracker.ietf.org/doc/draft-ietf-rtcweb-data-protocol/",
+        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-data-protocol",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "RTCWeb Data Channel Protocol"
@@ -1954,7 +1954,7 @@
             "Justin Uberti"
         ],
         "date": "20 March 2016",
-        "href": "https://datatracker.ietf.org/doc/draft-ietf-rtcweb-ip-handling/",
+        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-ip-handling",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "WebRTC IP Address Handling Recommendations"
@@ -1965,7 +1965,7 @@
             "Cullen Jennings"
         ],
         "date": "22 October 2013",
-        "href": "https://datatracker.ietf.org/doc/draft-ietf-rtcweb-jsep/",
+        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-jsep",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Javascript Session Establishment Protocol"
@@ -1975,7 +1975,7 @@
             "H. Alvestrand"
         ],
         "date": "14 February 2014",
-        "href": "https://datatracker.ietf.org/doc/draft-ietf-rtcweb-overview/",
+        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-overview",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Overview: Real Time Protocols for Brower-based Applications"
@@ -1987,7 +1987,7 @@
             "J. Ott"
         ],
         "date": "17 March 2016",
-        "href": "https://datatracker.ietf.org/doc/draft-ietf-rtcweb-rtp-usage/",
+        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-rtp-usage",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Web Real-Time Communication (WebRTC): Media Transport and Use of RTP"
@@ -1997,7 +1997,7 @@
             "Eric Rescorla"
         ],
         "date": "22 January 2014",
-        "href": "https://datatracker.ietf.org/doc/draft-ietf-rtcweb-security/",
+        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-security",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Security Considerations for WebRTC"
@@ -2007,7 +2007,7 @@
             "Eric Rescorla"
         ],
         "date": "10 December 2016",
-        "href": "https://datatracker.ietf.org/doc/draft-ietf-rtcweb-security-arch/",
+        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-security-arch",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "WebRTC Security Architecture"
@@ -2017,7 +2017,7 @@
             "H. Alvestrand"
         ],
         "date": "31 October 2016",
-        "href": "https://datatracker.ietf.org/doc/draft-ietf-rtcweb-transports/",
+        "href": " https://tools.ietf.org/html/draft-ietf-rtcweb-transports",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Transports for RTCWEB"
@@ -2060,7 +2060,7 @@
             "G. Camarillo"
         ],
         "date": "20 March 2017",
-        "href": "https://datatracker.ietf.org/doc/draft-ietf-mmusic-sctp-sdp/",
+        "href": " https://tools.ietf.org/html/draft-ietf-mmusic-sctp-sdp",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Session Description Protocol (SDP) Offer/Answer Procedures For Stream Control Transmission Protocol (SCTP) over Datagram Transport Layer Security (DTLS) Transport"
@@ -2188,7 +2188,7 @@
             "P. Matthews"
         ],
         "date": "16 February 2017",
-        "href": "https://datatracker.ietf.org/doc/draft-ietf-tram-stunbis/",
+        "href": " https://tools.ietf.org/html/draft-ietf-tram-stunbis",
         "publisher": "IETF",
         "status": "Internet Draft (work in progress)",
         "title": "Session Traversal Utilities for NAT (STUN)"
@@ -2272,7 +2272,7 @@
             "J. Polk"
         ],
         "date": "22 August 2016",
-        "href": "https://datatracker.ietf.org/doc/draft-ietf-tsvwg-rtcweb-qos",
+        "href": " https://tools.ietf.org/html/draft-ietf-tsvwg-rtcweb-qos",
         "publisher": "IETF",
         "status": "Internet Draft (work in progress)",
         "title": "DSCP Packet Markings for WebRTC QoS"

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -219,7 +219,7 @@
             "C. Jennings"
         ],
         "date": "31 August 2017",
-        "href": " https://tools.ietf.org/html/draft-ietf-mmusic-sdp-bundle-negotiation",
+        "href": "https://tools.ietf.org/html/draft-ietf-mmusic-sdp-bundle-negotiation",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Negotiating Media Multiplexing Using the Session Description Protocol (SDP)"


### PR DESCRIPTION
Per https://github.com/w3c/webrtc-pc/issues/1629