### PR TITLE
Add reference to HTTP-JFV

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1288,6 +1288,16 @@
     "HTMLMEDIACAPTURE": {
         "aliasOf": "html-media-capture"
     },
+    "HTTP-JFV": {
+        "authors": [
+            "J. Reschke"
+        ],
+        "date": "24 October 2017",
+        "href": "https://tools.ietf.org/html/draft-reschke-http-jfv",
+        "publisher": "IETF",
+        "status": "Active Internet-Draft",
+        "title": "A JSON Encoding for HTTP Header Field Values"
+    },
     "HTTP-PEP-971121": {
         "aliasOf": "http-pep"
     },


### PR DESCRIPTION
A draft spec for using JSON encode the value of an HTTP header.  Used in the draft REPORTING and NETWORK-ERROR-LOGGING specs.