### PR TITLE
Test merge of FIDO Alliance references

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1307,6 +1307,12 @@
     "HTTP11": {
         "aliasOf": "RFC7230"
     },
+    "IANA-COSE": {
+        "authors": ["Francesca Palombini", "Matt Miller", "Justin Richer", "Carsten Bormann"],
+        "publisher": "Internet Assigned Numbers Authority",
+        "title": "CBOR Object Signing and Encryption (COSE)",
+        "href": "https://www.iana.org/assignments/cose/cose.xhtml"
+    },
     "IANA-MEDIA-TYPES": {
         "href": "https://www.iana.org/assignments/media-types/",
         "title": "Media Types",


### PR DESCRIPTION
[FIDO Alliance](https://fidoalliance.org/) has been maintaining their own local `biblio.json` of references for their specifications. This is one of those references that I'm using as a test before potentially merging in the other ~200 references.