### PR TITLE
WEBGL: Add v1.0.3 Khronos Specification alongside the latest draft

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2679,7 +2679,20 @@
         "title": "WebGL Specification, Version 1.0",
         "rawDate": "2017-08-09",
         "publisher": "Khronos",
-        "repository": "https://github.com/KhronosGroup/WebGL"
+        "repository": "https://github.com/KhronosGroup/WebGL",
+        "versions": {
+            "20141027": {
+                "authors": [
+                    "Dean Jackson"
+                ],
+                "href": "https://www.khronos.org/registry/webgl/specs/1.0.3/",
+                "title": "WebGL Specification",
+                "rawDate": "2014-10-27"
+            }
+        }
+    },
+    "WEBGL-103": {
+        "aliasOf": "WEBGL-1-20141027"
     },
     "WEBGL-2": {
         "authors": [


### PR DESCRIPTION
We (https://github.com/w3c/webmediaapi) would like to be able to refer to a dated Specification rather than the latest working draft of WebGL v1.

This PR adds the last release of the specification (1.0.3) as a version of WEBGL-1 (I think this is the best practice?), and adds a vanity alias: WEBGL-103.