### PR TITLE
Added entry for re3data metadata schema

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -3239,6 +3239,37 @@
             }
         }
     },
+    "re3data-schema": {
+        "href": "https://doi.org/10.2312/re3.008",
+        "title": "Metadata Schema for the Description of Research Data Repositories: version 3",
+        "authors": [
+          "Jessika Rücknagel",
+          "Paul Vierkant",
+          "Robert Ulrich",
+          "Gabriele Kloska",
+          "Edeltraud Schnepf",
+          "David Fichtmüller",
+          "Evelyn Reuter",
+          "Angelika Semrau",
+          "Maxi Kindling",
+          "Heinz Pampel",
+          "Michael Witt",
+          "Florian Fritze",
+          "Stephanie van de Sandt",
+          "Jens Klump",
+          "Hans-Jürgen Goebelbecker",
+          "Michael Skarupianski",
+          "Roland Bertelmann",
+          "Peter Schirmbacher",
+          "Frank Scholze",
+          "Claudia Kramer",
+          "Claudio Fuchs",
+          "Shaked Spier",
+          "Agnes Kirchhoff"
+        ],
+        "publisher": "GFZ Potsdam",
+        "rawDate": "2015-12-17"
+    },
     "dcat-ap": {
         "href": "https://joinup.ec.europa.eu/asset/dcat_application_profile/",
         "title": "DCAT Application Profile for data portals in Europe. Version 1.1",


### PR DESCRIPTION
The metadata schema used by the [re3data.org](https://www.re3data.org/) registry of research data repositories:

https://www.re3data.org/schema