### PR TITLE
Give priority to href over edDraft in reverse lookup

### DIFF
--- a/lib/bibref.js
+++ b/lib/bibref.js
@@ -130,10 +130,15 @@ function prepareReverseLookup(refs) {
             href = normalizeUrl(href);
             output[href] = refs[ref.versionOf || k];
         }
+    });
+    Object.keys(refs).forEach(function(k) {
+        var ref = refs[k];
         var edDraft = ref.edDraft;
-        if (edDraft && !(edDraft in output)) {
+        if (edDraft) {
             edDraft = normalizeUrl(edDraft);
-            output[edDraft] = refs[ref.versionOf || k]; 
+            if (!(edDraft in output)) {
+                output[edDraft] = refs[ref.versionOf || k];
+            }
         }
     });
     return output;

--- a/test/bibref.js
+++ b/test/bibref.js
@@ -338,6 +338,22 @@ suite('Test bibref reverseLookup API', function() {
         assert(edDraft in output);
         assert.equal("Bar", output[edDraft].title);
     });
+
+    test('returns the right ref even when url also exists as edDraft', function() {
+        var foo = "http://example.com/foof";
+        var bar = "http://example.com/barf";
+        var b = bibref.create({
+            foo: { title: "Foo", href: foo },
+            fooEd: { title: "Foo ED", edDraft: foo },
+            barEd: { title: "Bar ED", edDraft: bar },
+            bar: { title: "Bar", href: bar }
+        });
+        var output = b.reverseLookup([foo, bar]);
+        assert(foo in output);
+        assert.equal("Foo", output[foo].title);
+        assert(bar in output);
+        assert.equal("Bar", output[bar].title);
+    });
 });
 
 suite('Test bibref normalizeUrl API', function() {


### PR DESCRIPTION
Fix for #450.

Code that populated the reverse lookup table seemed to be willing to give priority to `href` over `edDraft`, but it had 2 bugs:
1. it checked for `edDraft` in the properties of the output object not to override a previous entry, but the entry that is inserted is `normalizeUrl(edDraft)`, not `edDraft`
2. it did not add all `href` entries before looking at `edDraft`.

New test that makes sure that the returned ref is always the one that matches `href` if there is one added.