### PR TITLE
Add aliases for the unleveled version of each css spec

### DIFF
--- a/refs/unleveled-css-alias.json
+++ b/refs/unleveled-css-alias.json
@@ -1,0 +1,215 @@
+{
+    "css-align": {
+        "aliasOf": "css-align-3"
+    },
+    "css-animations": {
+        "aliasOf": "css-animations-1"
+    },
+    "css-backgrounds": {
+        "aliasOf": "css-backgrounds-3"
+    },
+    "css-box": {
+        "aliasOf": "css-box-3"
+    },
+    "css-break": {
+        "aliasOf": "css-break-3"
+    },
+    "css-cascade": {
+        "aliasOf": "css-cascade-4"
+    },
+    "css-color": {
+        "aliasOf": "css-color-4"
+    },
+    "css-conditional": {
+        "aliasOf": "css-conditional-3"
+    },
+    "css-contain": {
+        "aliasOf": "css-contain-1"
+    },
+    "css-content": {
+        "aliasOf": "css-content-3"
+    },
+    "css-counter-styles": {
+        "aliasOf": "css-counter-styles-3"
+    },
+    "css-device-adapt": {
+        "aliasOf": "css-device-adapt-1"
+    },
+    "css-display": {
+        "aliasOf": "css-display-3"
+    },
+    "css-egg": {
+        "aliasOf": "css-egg-1"
+    },
+    "css-env": {
+        "aliasOf": "css-env-1"
+    },
+    "css-exclusions": {
+        "aliasOf": "css-exclusions-1"
+    },
+    "css-extensions": {
+        "aliasOf": "css-extensions-1"
+    },
+    "css-flexbox": {
+        "aliasOf": "css-flexbox-1"
+    },
+    "css-floats": {
+        "aliasOf": "css-floats-3"
+    },
+    "css-font-loading": {
+        "aliasOf": "css-font-loading-3"
+    },
+    "css-fonts": {
+        "aliasOf": "css-fonts-3"
+    },
+    "css-forms": {
+        "aliasOf": "css-forms-1"
+    },
+    "css-gcpm": {
+        "aliasOf": "css-gcpm-3"
+    },
+    "css-grid": {
+        "aliasOf": "css-grid-1"
+    },
+    "css-images": {
+        "aliasOf": "css-images-3"
+    },
+    "css-inline": {
+        "aliasOf": "css-inline-3"
+    },
+    "css-line-grid": {
+        "aliasOf": "css-line-grid-1"
+    },
+    "css-lists": {
+        "aliasOf": "css-lists-3"
+    },
+    "css-logical": {
+        "aliasOf": "css-logical-1"
+    },
+    "css-multicol": {
+        "aliasOf": "css-multicol-1"
+    },
+    "css-namespaces": {
+        "aliasOf": "css-namespaces-3"
+    },
+    "css-overflow": {
+        "aliasOf": "css-overflow-3"
+    },
+    "css-page": {
+        "aliasOf": "css-page-3"
+    },
+    "css-page-floats": {
+        "aliasOf": "css-page-floats-3"
+    },
+    "css-page-template": {
+        "aliasOf": "css-page-template-1"
+    },
+    "css-position": {
+        "aliasOf": "css-position-3"
+    },
+    "css-preslev": {
+        "aliasOf": "css-preslev-1"
+    },
+    "css-pseudo": {
+        "aliasOf": "css-pseudo-4"
+    },
+    "css-regions": {
+        "aliasOf": "css-regions-1"
+    },
+    "css-rhythm": {
+        "aliasOf": "css-rhythm-1"
+    },
+    "css-round-display": {
+        "aliasOf": "css-round-display-1"
+    },
+    "css-ruby": {
+        "aliasOf": "css-ruby-1"
+    },
+    "css-scoping": {
+        "aliasOf": "css-scoping-1"
+    },
+    "css-scroll-anchoring": {
+        "aliasOf": "css-scroll-anchoring-1"
+    },
+    "css-scroll-snap": {
+        "aliasOf": "css-scroll-snap-1"
+    },
+    "css-scrollbars": {
+        "aliasOf": "css-scrollbars-1"
+    },
+    "css-shadow-parts": {
+        "aliasOf": "css-shadow-parts-1"
+    },
+    "css-shapes": {
+        "aliasOf": "css-shapes-1"
+    },
+    "css-size-adjust": {
+        "aliasOf": "css-size-adjust-1"
+    },
+    "css-sizing": {
+        "aliasOf": "css-sizing-3"
+    },
+    "css-speech": {
+        "aliasOf": "css-speech-1"
+    },
+    "css-style-attr": {
+        "aliasOf": "css-style-attr-1"
+    },
+    "css-syntax": {
+        "aliasOf": "css-syntax-3"
+    },
+    "css-tables": {
+        "aliasOf": "css-tables-3"
+    },
+    "css-template": {
+        "aliasOf": "css-template-1"
+    },
+    "css-text": {
+        "aliasOf": "css-text-3"
+    },
+    "css-text-decor": {
+        "aliasOf": "css-text-decor-3"
+    },
+    "css-timing": {
+        "aliasOf": "css-timing-1"
+    },
+    "css-transforms": {
+        "aliasOf": "css-transforms-1"
+    },
+    "css-transitions": {
+        "aliasOf": "css-transitions-1"
+    },
+    "css-ui": {
+        "aliasOf": "css-ui-4"
+    },
+    "css-values": {
+        "aliasOf": "css-values-4"
+    },
+    "css-variables": {
+        "aliasOf": "css-variables-1"
+    },
+    "css-will-change": {
+        "aliasOf": "css-will-change-1"
+    },
+    "css-writing-modes": {
+        "aliasOf": "css-writing-modes-4"
+    },
+    "cssom": {
+        "aliasOf": "cssom-1"
+    },
+    "cssom-view": {
+        "aliasOf": "cssom-view-1"
+    },
+    "mediaqueries": {
+        "aliasOf": "mediaqueries-4"
+    },
+    "selectors": {
+        "aliasOf": "selectors-4"
+    },
+    "selectors-nonelement": {
+        "aliasOf": "selectors-nonelement-1"
+    },
+    "web-animations": {
+        "aliasOf": "web-animations-1"
+    }
+}


### PR DESCRIPTION
Made to solve https://github.com/w3c/web-platform-tests/issues/10707

Not 100% sure this is the right way of doing it, but let's start with something naive, and make it better if that doesn't cut it.

This is manually generated from the full list of specs in the css-wg's repo, matching the unleveled spec with the same level as what the csswg server does (at the time of writing).