### PR TITLE
Add IANA registry for TLS Supported Groups

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1340,6 +1340,11 @@
         "title": "TLS Cipher Suite Registry",
         "publisher": "IANA"
     },
+    "IANA-TLS-GROUPS": {
+        "href": "https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8",
+        "title": "TLS Supported Groups Registry",
+        "publisher": "IANA"
+    },
     "IANA-TSV": {
         "authors": [
             "Paul Lindner"


### PR DESCRIPTION
This is needed by [[WEBRTC-STATS]].
https://github.com/w3c/webrtc-stats/pull/355