### PR TITLE
Make "WICG-MST-CONTENT-HINT" an alias

### DIFF
--- a/refs/wicg.json
+++ b/refs/wicg.json
@@ -277,12 +277,7 @@
         "aliasOf": "MEDIASESSION"
     },
     "WICG-MST-CONTENT-HINT": {
-        "href": "https://wicg.github.io/mst-content-hint/",
-        "title": "MediaStreamTrack Content Hints",
-        "status": "Living Standard",
-        "publisher": "WICG",
-        "source": "https://wicg.github.io/admin/biblio.json",
-        "repository": "https://github.com/wicg/mst-content-hint"
+        "aliasOf": "mst-content-hint"
     },
     "WICG-NETINFO": {
         "aliasOf": "NETINFO"


### PR DESCRIPTION
https://wicg.github.io/mst-content-hint/ is 404 so keeping it around
is not useful.

See also https://github.com/WICG/admin/pull/58.