### PR TITLE
Update "xpath" (XPath 1.0) URL

### DIFF
--- a/overwrites/w3c.json
+++ b/overwrites/w3c.json
@@ -26,5 +26,8 @@
     "webvr": {
         "href": { "replaceWith": "https://immersive-web.github.io/webvr/spec/1.1/" },
         "repository": { "replaceWith": "https://github.com/immersive-web/webxr" }
+    },
+    "xpath": {
+        "href": { "replaceWith": "https://www.w3.org/TR/xpath-10/" }
     }
 }


### PR DESCRIPTION
This change makes https://www.w3.org/TR/xpath-10/ the URL XPath 1.0 (key: "xpath"), rather than https://www.w3.org/TR/xpath (which now redirects to https://www.w3.org/TR/xpath/all/ and has become an index/overview page rather than being the actual XPath 1.0 spec).