### PR TITLE
Update "webvr" URLs

### DIFF
--- a/overwrites/w3c.json
+++ b/overwrites/w3c.json
@@ -22,5 +22,9 @@
     },
     "service-workers-1": {
         "edDraft": { "replaceWith": "https://w3c.github.io/ServiceWorker/" }
+    },
+    "webvr": {
+        "href": { "replaceWith": "https://immersive-web.github.io/webvr/spec/1.1/" },
+        "repository": { "replaceWith": "https://github.com/immersive-web/webxr" }
     }
 }


### PR DESCRIPTION
This change makes https://immersive-web.github.io/webvr/spec/1.1/ the URL for the WebVR spec (key: "webvr"), rather than the URL https://w3c.github.io/webvr/spec/latest/ (which now redirects to a 404).  The change also updates the "repository" URL to https://github.com/immersive-web/webxr (which is where the old https://github.com/w3c/webvr now redirects to).