### PR TITLE
Add [EVERGREEN-WEB] reference

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1,4 +1,14 @@
 {
+    "EVERGREEN-WEB": {
+       "href": "https://www.w3.org/2001/tag/doc/evergreen-web/",
+       "title": "The evergreen Web",
+       "publisher": "W3C",
+       "status": "TAG Finding",
+       "authors": [
+           "Hadley Beeman"
+       ],
+       "rawDate": "2017-02-09"
+     },
     "3GPP-TT": {
         "title": "Transparent end-to-end Packet switched Streaming Service (PSS) Timed text format (Release 12)",
         "href": "http://www.3gpp.org/ftp/Specs/archive/26_series/26.245/26245-c00.zip",
@@ -2302,7 +2312,7 @@
         ],
         "href": "https://www.w3.org/2001/tag/doc/web-https",
         "title": "Securing the Web",
-        "status": "Finding",
+        "status": "TAG Finding",
         "publisher": "W3C"
     },
     "SELECT": {
@@ -4407,7 +4417,7 @@
         "href": "https://www.w3.org/2001/tag/doc/promises-guide",
         "title": "Writing Promise-Using Specifications",
         "publisher": "W3C",
-        "status": "Finding of the W3C TAG",
+        "status": "TAG Finding",
         "authors": [
             "Domenic Denicola"
         ],


### PR DESCRIPTION
Additionally make the status of TAG findings consistent.

Closes #484.