### PR TITLE
brought reference for ETSI TS 102366 to latest version

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1141,8 +1141,14 @@
         "aliasOf": "RFC2631"
     },
     "ETSI102366": {
-        "title": "Digital Audio Compression(AC-3, Enhanced AC-3) Standard v1.3.1",
-        "href": "http://www.etsi.org/deliver/etsi_ts/102300_102399/102366/01.03.01_60/ts_102366v010301p.pdf"
+        "title": "ETSI TS 102 366: Digital Audio Compression(AC-3, Enhanced AC-3) Standard",
+        "href": "http://www.etsi.org/deliver/etsi_ts/102300_102399/102366/01.04.01_60/ts_102366v010401p.pdf"
+        "status": "ETSI Technical Specification",
+        "rawDate": "2017-09",
+        "publisher": "European Telecommunications Standards Institute",
+        "deliveredBy": [
+            "https://portal.etsi.org/tb.aspx?tbid=92&SubTB=92"
+        ]
     },
     "EVERGREEN-WEB": {
         "href": "https://www.w3.org/2001/tag/doc/evergreen-web/",


### PR DESCRIPTION
- changed format of spec name (removed version number, added ETSI TS number)
- added delivered-by