### PR TITLE
three video standards (ITU, SMPTE)

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2425,6 +2425,13 @@
     "SMPTE2052-1": {
         "aliasOf": "SMPTE2052-1-2013"
     },
+    "SMPTE296": {
+        "title": "ST 296:2012 - SMPTE Standard - 1280 × 720 Progressive Image 4:2:2 and 4:4:4 Sample Structure — Analog and Digital Representation and Analog Interface",
+        "href": "https://ieeexplore.ieee.org/document/7291722",
+        "publisher": "SMPTE",
+        "date": "2012-05-17",
+        "status": "Standard"
+    },
     "SMPTE2052-1-2010": {
         "title": "SMPTE ST 2052-1:2010 \"Timed Text Format (SMPTE-TT)\"",
         "href": "https://doi.org/10.5594/SMPTE.ST2052-1.2010",
@@ -4210,6 +4217,20 @@
         "status": "International Standard",
         "date": "2008",
         "isoNumber": "ISO 639-5:2008"
+    },
+    "ITU-R-BT.601": {
+        "href": "https://www.itu.int/rec/R-REC-BT.601/",
+        "title": "BT.601 : Studio encoding parameters of digital television for standard 4:3 and wide screen 16:9 aspect ratios",
+        "status": "Recommendation",
+        "date": "2011-03-08",
+        "publisher": "ITU"
+    },
+    "ITU-R-BT.709": {
+        "href": "https://www.itu.int/rec/R-REC-BT.709/",
+        "title": "BT.709 : Parameter values for the HDTV standards for production and international programme exchange",
+        "status": "Recommendation",
+        "date": "2015-06-17",
+        "publisher": "ITU"
     },
     "json-patch": {
         "aliasOf": "rfc6902"

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2426,8 +2426,8 @@
         "aliasOf": "SMPTE2052-1-2013"
     },
     "SMPTE296": {
-        "title": "ST 296:2012 - SMPTE Standard - 1280 × 720 Progressive Image 4:2:2 and 4:4:4 Sample Structure — Analog and Digital Representation and Analog Interface",
-        "href": "https://ieeexplore.ieee.org/document/7291722",
+        "title": "ST 296:2012, 1280 × 720 Progressive Image 4:2:2 and 4:4:4 Sample Structure — Analog and Digital Representation and Analog Interface",
+        "href": "https://doi.org/10.5594/SMPTE.ST296.2012",
         "publisher": "SMPTE",
         "date": "2012-05-17",
         "status": "Standard"
@@ -4220,14 +4220,14 @@
     },
     "ITU-R-BT.601": {
         "href": "https://www.itu.int/rec/R-REC-BT.601/",
-        "title": "BT.601 : Studio encoding parameters of digital television for standard 4:3 and wide screen 16:9 aspect ratios",
+        "title": "Recommendation ITU-R BT.601-7 (03/2011), Studio encoding parameters of digital television for standard 4:3 and wide screen 16:9 aspect ratios",
         "status": "Recommendation",
         "date": "2011-03-08",
         "publisher": "ITU"
     },
     "ITU-R-BT.709": {
         "href": "https://www.itu.int/rec/R-REC-BT.709/",
-        "title": "BT.709 : Parameter values for the HDTV standards for production and international programme exchange",
+        "title": "Recommendation ITU-R BT.709-6 (06/2015), Parameter values for the HDTV standards for production and international programme exchange",
         "status": "Recommendation",
         "date": "2015-06-17",
         "publisher": "ITU"

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2429,7 +2429,7 @@
         "title": "ST 296:2012, 1280 × 720 Progressive Image 4:2:2 and 4:4:4 Sample Structure — Analog and Digital Representation and Analog Interface",
         "href": "https://doi.org/10.5594/SMPTE.ST296.2012",
         "publisher": "SMPTE",
-        "date": "2012-05-17",
+        "rawDate": "2012-05-17",
         "status": "Standard"
     },
     "SMPTE2052-1-2010": {
@@ -4222,14 +4222,14 @@
         "href": "https://www.itu.int/rec/R-REC-BT.601/",
         "title": "Recommendation ITU-R BT.601-7 (03/2011), Studio encoding parameters of digital television for standard 4:3 and wide screen 16:9 aspect ratios",
         "status": "Recommendation",
-        "date": "2011-03-08",
+        "rawDate": "2011-03-08",
         "publisher": "ITU"
     },
     "ITU-R-BT.709": {
         "href": "https://www.itu.int/rec/R-REC-BT.709/",
         "title": "Recommendation ITU-R BT.709-6 (06/2015), Parameter values for the HDTV standards for production and international programme exchange",
         "status": "Recommendation",
-        "date": "2015-06-17",
+        "rawDate": "2015-06-17",
         "publisher": "ITU"
     },
     "json-patch": {


### PR DESCRIPTION
Three video standards:

1. ITU-R BT.601, for standard definition (480p) television
2. SMPTE ST296, for 720p with the same colorimetry as BT.709
3. ITU-R BT.709, for 1080p

Oddly, smpte.org seems to redirect to ieeexplore.ieee.org, which is why I used that href for the smpte spec. See https://www.smpte.org/standards/document-index/ST search for 296-2012 and follow their link.