### PR TITLE
Added 3 DCMI specifications about application profiles

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -811,8 +811,41 @@
             }
         }
     },
+    "DCAP": {
+        "authors": [
+            "Karen Coyle",
+            "Thomas Baker"
+        ],
+        "href": "http://dublincore.org/documents/profile-guidelines/",
+        "title": "Guidelines for Dublin Core Application Profiles",
+        "rawDate": "2009-05-18",
+        "publisher": "DCMI",
+        "status": "DCMI Recommended Resource"
+    },
+    "DCDSP": {
+        "authors": [
+            "Mikael Nilsson"
+        ],
+        "href": "http://dublincore.org/documents/dc-dsp/",
+        "title": "Description Set Profiles: A constraint language for Dublin Core Application Profiles",
+        "rawDate": "2008-03-31",
+        "publisher": "DCMI",
+        "status": "DCMI Working Draft"
+    },
     "DCI-P3": {
         "aliasOf": "SMPTE431-2"
+    },
+    "DCSF": {
+        "authors": [
+            "Mikael Nilsson",
+            "Thomas Baker",
+            "Pete Johnston"
+        ],
+        "href": "http://dublincore.org/documents/singapore-framework/",
+        "title": "The Singapore Framework for Dublin Core Application Profiles",
+        "rawDate": "2008-01-14",
+        "publisher": "DCMI",
+        "status": "DCMI Recommended Resource"
     },
     "DCTERMS": {
         "authors": [


### PR DESCRIPTION
Cited in https://w3c.github.io/dxwg/profiles/ :

- [Guidelines for Dublin Core Application Profiles](http://dublincore.org/documents/profile-guidelines/)
- [The Singapore Framework for Dublin Core Application Profiles](http://dublincore.org/documents/singapore-framework/)
- [Description Set Profiles: A constraint language for Dublin Core Application Profiles](http://dublincore.org/documents/dc-dsp/)