### PR TITLE
add Bradford Chromatic Adaptation Transform

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -247,8 +247,7 @@
             "R. W. G. Hunt"
         ],
         "rawDate": "1998-06",
-        "title": "A Chromatic Adaptation Transform and a Colour Inconstancy Index. Color Research & Application 23(3)",
-        "pages": "154-158",
+        "title": "A Chromatic Adaptation Transform and a Colour Inconstancy Index. Color Research & Application 23(3) 154-158",
         "publisher": "Wiley"
     },
     "BUNDLE": {

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -248,7 +248,7 @@
         ],
         "rawDate": "1998-06",
         "title": "A Chromatic Adaptation Transform and a Colour Inconstancy Index. Color Research & Application 23(3)",
-        "pages": "154 - 158",
+        "pages": "154-158",
         "publisher": "Wiley"
     },
     "BUNDLE": {

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -241,6 +241,16 @@
         "href": "https://web-beta.archive.org/web/20130114131937/http://bondi.omtp.org/1.11/apis/apifeatures.html",
         "title": "BONDI API Features v1.11"
     },
+    "Bradford CAT": {
+        "authors": [
+            "Ming R. Luo",
+            "R. W. G. Hunt"
+        ],
+        "rawDate": "1998-6",
+        "title": "A Chromatic Adaptation Transform and a Colour Inconstancy Index. Color Research & Application 23(3)",
+        "pages": "154 - 158",
+        "publisher": "Wiley"
+    },
     "BUNDLE": {
         "authors": [
             "C. Holmberg",

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -246,7 +246,7 @@
             "Ming R. Luo",
             "R. W. G. Hunt"
         ],
-        "rawDate": "1998-6",
+        "rawDate": "1998-06",
         "title": "A Chromatic Adaptation Transform and a Colour Inconstancy Index. Color Research & Application 23(3)",
         "pages": "154 - 158",
         "publisher": "Wiley"


### PR DESCRIPTION
Hoping I did this right. The schema doesn't offer much guidance on journal articles; following other examples I put the journal, volume etc in the title.

Here is the bibref

```
@article{article,
author = {Luo, Ming and W. G. Hunt, R},
year = {1998},
month = {06},
pages = {154 - 158},
title = {A Chromatic Adaptation Transform and a Colour Inconstancy Index},
volume = {23},
journal = {Color Research & Application},
doi = {10.1002/(SICI)1520-6378(199806)23:3<154::AID-COL7>3.0.CO;2-P}
}
```