### PR TITLE
fix(biblio): bad id

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -241,7 +241,7 @@
         "href": "https://web-beta.archive.org/web/20130114131937/http://bondi.omtp.org/1.11/apis/apifeatures.html",
         "title": "BONDI API Features v1.11"
     },
-    "Bradford CAT": {
+    "Bradford-CAT": {
         "authors": [
             "Ming R. Luo",
             "R. W. G. Hunt"


### PR DESCRIPTION
Validation failure (id with space)... not sure how this slipped through? 