### PR TITLE
Revamp Unicode specs

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -208,28 +208,13 @@
         "publisher": "IETF"
     },
     "BIDI": {
-        "authors": [
-            "Mark Davis",
-            "Aharon Lanin",
-            "Andrew Glass"
-        ],
-        "href": "https://www.unicode.org/reports/tr9/tr9-37.html",
-        "publisher": "Unicode Consortium",
-        "date": "14 May 2017",
-        "status": "Unicode Standard Annex #9",
-        "title": "Unicode Bidirectional Algorithm"
+        "aliasOf": "UAX9"
     },
     "BLOB": {
         "aliasOf": "FileAPI"
     },
     "BOCU1": {
-        "authors": [
-            "M. Scherer",
-            "M. Davis"
-        ],
-        "href": "https://www.unicode.org/notes/tn6/",
-        "publisher": "Unicode Consortium",
-        "title": "UTN #6: BOCU-1: MIME-Compatible Unicode Compression"
+        "aliasOf": "UTN6"
     },
     "BONDI-ARCH-SECURITY-11": {
         "date": "27 January 2010",
@@ -326,12 +311,7 @@
         "rawDate": "2013-12-10"
     },
     "CESU8": {
-        "authors": [
-            "T. Phipps"
-        ],
-        "href": "https://www.unicode.org/reports/tr26/",
-        "title": "UTR #26: Compatibility Encoding Scheme For UTF-16: 8-BIT (CESU-8)",
-        "publisher": "Unicode Consortium"
+        "aliasOf": "UTR26"
     },
     "CGM": {
         "aliasOf": "NOTE-cgm"
@@ -2821,101 +2801,6 @@
     "TYPED-ARRAYS": {
         "aliasOf": "typedarray"
     },
-    "UAX11": {
-        "authors": [
-            "Ken Lunde 小林劍"
-        ],
-        "href": "https://www.unicode.org/reports/tr11/tr11-33.html",
-        "title": "East Asian Width",
-        "date": "14 May 2017",
-        "status": "Unicode Standard Annex #11",
-        "publisher": "Unicode Consortium"
-    },
-    "UAX14": {
-        "authors": [
-            "Andy Heninger"
-        ],
-        "href": "https://www.unicode.org/reports/tr14/tr14-39.html",
-        "title": "Unicode Line Breaking Algorithm",
-        "date": "12 June 2017",
-        "status": "Unicode Standard Annex #14",
-        "publisher": "Unicode Consortium"
-    },
-    "UAX15": {
-        "authors": [
-            "Mark Davis",
-            "Ken Whistler"
-        ],
-        "href": "https://www.unicode.org/reports/tr15/tr15-45.html",
-        "title": "Unicode Normalization Forms",
-        "date": "26 May 2017",
-        "status": "Unicode Standard Annex #15",
-        "publisher": "Unicode Consortium"
-    },
-    "UAX21": {
-        "authors": [
-            "Mark Davis"
-        ],
-        "href": "https://www.unicode.org/reports/tr21/tr21-5.html",
-        "title": "Case Mappings",
-        "date": "26 March 2001",
-        "status": "Unicode Standard Annex #21",
-        "publisher": "Unicode Consortium",
-        "obsoletedBy": [
-            "UNICODE"
-        ]
-    },
-    "UAX24": {
-        "authors": [
-            "Mark Davis",
-            "Ken Whistler"
-        ],
-        "href": "https://www.unicode.org/reports/tr24/tr24-27.html",
-        "title": "Unicode Script Property",
-        "date": "26 May 2017",
-        "status": "Unicode Standard Annex #24",
-        "publisher": "Unicode Consortium"
-    },
-    "UAX27": {
-        "authors": [
-            "Mark Davis",
-            "Michael Everson"
-        ],
-        "etAl": true,
-        "href": "https://www.unicode.org/unicode/reports/tr27/tr27-4.html",
-        "title": "Unicode 3.1.0",
-        "date": "16 May 2001",
-        "status": "Unicode Standard Annex #27",
-        "publisher": "Unicode Consortium",
-        "obsoletedBy": [
-            "UNICODE"
-        ]
-    },
-    "UAX29": {
-        "authors": [
-            "Mark Davis",
-            "Laurențiu Iancu"
-        ],
-        "href": "https://www.unicode.org/reports/tr29/tr29-31.html",
-        "title": "Unicode Text Segmentation",
-        "date": "13 June 2017",
-        "status": "Unicode Standard Annex #29",
-        "publisher": "Unicode Consortium"
-    },
-    "UAX35": {
-        "authors": [
-            "Mark Davis",
-            "CLDR committee members"
-        ],
-        "href": "https://www.unicode.org/reports/tr35/tr35-47/tr35.html",
-        "title": "Unicode Locale Data Markup Language (LDML)",
-        "date": "15 March 2017",
-        "status": "Unicode Standard Annex #35",
-        "publisher": "Unicode Consortium"
-    },
-    "UAX9": {
-        "aliasOf": "BIDI"
-    },
     "UI-AUTOMATION": {
         "href": "https://msdn.microsoft.com/en-us/library/ee684009%28v=vs.85%29.aspx",
         "title": "UI Automation",
@@ -2949,41 +2834,11 @@
         "status": "ED",
         "publisher": "W3C"
     },
-    "UNICODE": {
-        "href": "https://www.unicode.org/versions/latest/",
-        "publisher": "Unicode Consortium",
-        "title": "The Unicode Standard"
-    },
     "UNICODE-SECURITY": {
-        "authors": [
-            "Mark Davis",
-            "Michel Suignard"
-        ],
-        "href": "https://www.unicode.org/reports/tr36/",
-        "title": "Unicode Security Considerations",
-        "date": "19 September 2014",
-        "status": "Unicode Technical Report #36",
-        "publisher": "Unicode Consortium"
+        "aliasOf": "UTR36"
     },
     "UNICODE-SECURITY-MECHANISMS": {
-        "authors": [
-            "Mark Davis",
-            "Michel Suignard"
-        ],
-        "href": "https://www.unicode.org/reports/tr39/",
-        "title": "Unicode Security Mechanisms",
-        "date": "20 February 2019",
-        "status": "Unicode Technical Report #39",
-        "publisher": "Unicode Consortium"
-    },
-    "UNICODE32": {
-        "authors": [
-            "Unicode Consortium"
-        ],
-        "href": "https://www.unicode.org/versions/Unicode3.2.0/",
-        "title": "The Unicode Standard, Version 3.2.0",
-        "publisher": "Unicode Consortium",
-        "date": "27 March 2002"
+        "aliasOf": "UTR39"
     },
     "URI": {
         "aliasOf": "rfc3986"
@@ -3002,81 +2857,6 @@
     },
     "UTF-8": {
         "aliasOf": "rfc3629"
-    },
-    "UTR24": {
-        "authors": [
-            "Mark Davis"
-        ],
-        "href": "https://www.unicode.org/unicode/reports/tr24/tr24-3.html",
-        "title": "Script Names",
-        "date": "27 September 2001",
-        "status": "Unicode Technical Report #24",
-        "publisher": "Unicode Consortium"
-    },
-    "UTR36": {
-        "aliasOf": "UNICODE-SECURITY"
-    },
-    "UTR39": {
-        "aliasOf": "UNICODE-SECURITY-MECHANISMS"
-    },
-    "UTR51": {
-        "authors": [
-            "Mark Davis",
-            "Peter Edberg"
-        ],
-        "href": "https://www.unicode.org/reports/tr51/tr51-9.html",
-        "title": "Unicode Emoji 4.0",
-        "date": "22 November 2016",
-        "status": "Unicode Technical Report #51",
-        "publisher": "Unicode Consortium",
-        "obsoletedBy": [
-            "UTS51"
-        ]
-    },
-    "UTS10": {
-        "authors": [
-            "Mark Davis",
-            "Ken Whistler",
-            "Markus Scherer"
-        ],
-        "href": "https://www.unicode.org/reports/tr10/tr10-36.html",
-        "title": "Unicode Collation Algorithm",
-        "date": "16 June 2017",
-        "status": "Unicode Technical Standard #10",
-        "publisher": "Unicode Consortium"
-    },
-    "UTS22": {
-        "authors": [
-            "Mark Davis",
-            "Markus Scherer"
-        ],
-        "href": "https://www.unicode.org/reports/tr22/tr22-8.html",
-        "title": "Unicode Character Mapping Markup Language (CharmapML)",
-        "date": "31 May 2017",
-        "status": "Unicode Technical Standard #22",
-        "publisher": "Unicode Consortium"
-    },
-    "UTS46": {
-        "authors": [
-            "Mark Davis",
-            "Michel Suignard"
-        ],
-        "href": "https://www.unicode.org/reports/tr46/tr46-19.html",
-        "title": "Unicode IDNA Compatibility Processing",
-        "date": "8 June 2017",
-        "status": "Unicode Technical Standard #46",
-        "publisher": "Unicode Consortium"
-    },
-    "UTS51": {
-        "authors": [
-            "Mark Davis",
-            "Peter Edberg"
-        ],
-        "href": "https://www.unicode.org/reports/tr51/tr51-12.html",
-        "title": "Unicode Emoji",
-        "date": "18 May 2017",
-        "status": "Unicode Technical Standard #51",
-        "publisher": "Unicode Consortium"
     },
     "VTT708": {
         "title": "Conversion of 608/708 captions to WebVTT",

--- a/refs/csswg.json
+++ b/refs/csswg.json
@@ -140,42 +140,6 @@
         "rawDate": "2015-10",
         "href": "http://www.itu.int/rec/R-REC-BT.2020/en"
     },
-    "UAX44": {
-        "source": "http://dev.w3.org/csswg/biblio.ref",
-        "authors": [
-            "Mark Davis",
-            "Ken Whistler"
-        ],
-        "title": "Unicode Character Database",
-        "rawDate": "2013-09-25",
-        "href": "http://www.unicode.org/reports/tr44/"
-    },
-    "UNICODE6": {
-        "source": "http://dev.w3.org/csswg/biblio.ref",
-        "authors": [
-            "The Unicode Consortium"
-        ],
-        "title": "The Unicode Standard, Version 6.2.0",
-        "href": "http://www.unicode.org/versions/Unicode6.2.0/"
-    },
-    "UTN22": {
-        "source": "http://dev.w3.org/csswg/biblio.ref",
-        "authors": [
-            "Elika J. Etemad"
-        ],
-        "title": "Robust Vertical Text Layout",
-        "rawDate": "2005-04-25",
-        "href": "http://unicode.org/notes/tn22/"
-    },
-    "UTR50": {
-        "source": "http://dev.w3.org/csswg/biblio.ref",
-        "title": "Unicode Properties for Vertical Text Layout",
-        "authors": [
-            "Koji Ishii"
-        ],
-        "rawDate": "2013-08-31",
-        "href": "http://www.unicode.org/reports/tr50/"
-    },
     "WINDOWS-GLYPH-PROC": {
         "source": "http://dev.w3.org/csswg/biblio.ref",
         "title": "Windows Glyph Processing",

--- a/refs/unicode.json
+++ b/refs/unicode.json
@@ -1,0 +1,263 @@
+{
+    "UAX11": {
+        "authors": [
+            "Ken Lunde 小林劍"
+        ],
+        "href": "https://www.unicode.org/reports/tr11/tr11-33.html",
+        "title": "East Asian Width",
+        "date": "14 May 2017",
+        "status": "Unicode Standard Annex #11",
+        "publisher": "Unicode Consortium"
+    },
+    "UAX14": {
+        "authors": [
+            "Andy Heninger"
+        ],
+        "href": "https://www.unicode.org/reports/tr14/tr14-39.html",
+        "title": "Unicode Line Breaking Algorithm",
+        "date": "12 June 2017",
+        "status": "Unicode Standard Annex #14",
+        "publisher": "Unicode Consortium"
+    },
+    "UAX15": {
+        "authors": [
+            "Mark Davis",
+            "Ken Whistler"
+        ],
+        "href": "https://www.unicode.org/reports/tr15/tr15-45.html",
+        "title": "Unicode Normalization Forms",
+        "date": "26 May 2017",
+        "status": "Unicode Standard Annex #15",
+        "publisher": "Unicode Consortium"
+    },
+    "UAX21": {
+        "authors": [
+            "Mark Davis"
+        ],
+        "href": "https://www.unicode.org/reports/tr21/tr21-5.html",
+        "title": "Case Mappings",
+        "date": "26 March 2001",
+        "status": "Unicode Standard Annex #21",
+        "publisher": "Unicode Consortium",
+        "obsoletedBy": [
+            "UNICODE"
+        ]
+    },
+    "UAX24": {
+        "authors": [
+            "Mark Davis",
+            "Ken Whistler"
+        ],
+        "href": "https://www.unicode.org/reports/tr24/tr24-27.html",
+        "title": "Unicode Script Property",
+        "date": "26 May 2017",
+        "status": "Unicode Standard Annex #24",
+        "publisher": "Unicode Consortium"
+    },
+    "UAX27": {
+        "authors": [
+            "Mark Davis",
+            "Michael Everson"
+        ],
+        "etAl": true,
+        "href": "https://www.unicode.org/unicode/reports/tr27/tr27-4.html",
+        "title": "Unicode 3.1.0",
+        "date": "16 May 2001",
+        "status": "Unicode Standard Annex #27",
+        "publisher": "Unicode Consortium",
+        "obsoletedBy": [
+            "UNICODE"
+        ]
+    },
+    "UAX29": {
+        "authors": [
+            "Mark Davis",
+            "Laurențiu Iancu"
+        ],
+        "href": "https://www.unicode.org/reports/tr29/tr29-31.html",
+        "title": "Unicode Text Segmentation",
+        "date": "13 June 2017",
+        "status": "Unicode Standard Annex #29",
+        "publisher": "Unicode Consortium"
+    },
+    "UAX35": {
+        "authors": [
+            "Mark Davis",
+            "CLDR committee members"
+        ],
+        "href": "https://www.unicode.org/reports/tr35/tr35-47/tr35.html",
+        "title": "Unicode Locale Data Markup Language (LDML)",
+        "date": "15 March 2017",
+        "status": "Unicode Standard Annex #35",
+        "publisher": "Unicode Consortium"
+    },
+    "UAX44": {
+        "authors": [
+            "Mark Davis",
+            "Ken Whistler"
+        ],
+        "title": "Unicode Character Database",
+        "rawDate": "2013-09-25",
+        "href": "http://www.unicode.org/reports/tr44/"
+    },
+    "UAX9": {
+        "authors": [
+            "Mark Davis",
+            "Aharon Lanin",
+            "Andrew Glass"
+        ],
+        "href": "https://www.unicode.org/reports/tr9/tr9-37.html",
+        "publisher": "Unicode Consortium",
+        "date": "14 May 2017",
+        "status": "Unicode Standard Annex #9",
+        "title": "Unicode Bidirectional Algorithm"
+    },
+    "UNICODE": {
+        "href": "https://www.unicode.org/versions/latest/",
+        "publisher": "Unicode Consortium",
+        "title": "The Unicode Standard"
+    },
+    "UNICODE32": {
+        "authors": [
+            "Unicode Consortium"
+        ],
+        "href": "https://www.unicode.org/versions/Unicode3.2.0/",
+        "title": "The Unicode Standard, Version 3.2.0",
+        "publisher": "Unicode Consortium",
+        "date": "27 March 2002"
+    },
+    "UNICODE6": {
+        "authors": [
+            "The Unicode Consortium"
+        ],
+        "title": "The Unicode Standard, Version 6.2.0",
+        "href": "http://www.unicode.org/versions/Unicode6.2.0/"
+    },
+    "UTN22": {
+        "authors": [
+            "Elika J. Etemad"
+        ],
+        "title": "Robust Vertical Text Layout",
+        "rawDate": "2005-04-25",
+        "href": "http://unicode.org/notes/tn22/"
+    },
+    "UTN6": {
+        "authors": [
+            "M. Scherer",
+            "M. Davis"
+        ],
+        "href": "https://www.unicode.org/notes/tn6/",
+        "publisher": "Unicode Consortium",
+        "title": "UTN #6: BOCU-1: MIME-Compatible Unicode Compression"
+    },
+    "UTR24": {
+        "authors": [
+            "Mark Davis"
+        ],
+        "href": "https://www.unicode.org/unicode/reports/tr24/tr24-3.html",
+        "title": "Script Names",
+        "date": "27 September 2001",
+        "status": "Unicode Technical Report #24",
+        "publisher": "Unicode Consortium",
+        "obsoletedBy": [
+            "UAX24"
+        ]
+    },
+    "UTR26": {
+        "authors": [
+            "T. Phipps"
+        ],
+        "href": "https://www.unicode.org/reports/tr26/",
+        "title": "UTR #26: Compatibility Encoding Scheme For UTF-16: 8-BIT (CESU-8)",
+        "publisher": "Unicode Consortium"
+    },
+    "UTR36": {
+        "authors": [
+            "Mark Davis",
+            "Michel Suignard"
+        ],
+        "href": "https://www.unicode.org/reports/tr36/",
+        "title": "Unicode Security Considerations",
+        "date": "19 September 2014",
+        "status": "Unicode Technical Report #36",
+        "publisher": "Unicode Consortium"
+    },
+    "UTR39": {
+        "authors": [
+            "Mark Davis",
+            "Michel Suignard"
+        ],
+        "href": "https://www.unicode.org/reports/tr39/",
+        "title": "Unicode Security Mechanisms",
+        "date": "20 February 2019",
+        "status": "Unicode Technical Report #39",
+        "publisher": "Unicode Consortium"
+    },
+    "UTR50": {
+        "title": "Unicode Properties for Vertical Text Layout",
+        "authors": [
+            "Koji Ishii"
+        ],
+        "rawDate": "2013-08-31",
+        "href": "http://www.unicode.org/reports/tr50/"
+    },
+    "UTR51": {
+        "authors": [
+            "Mark Davis",
+            "Peter Edberg"
+        ],
+        "href": "https://www.unicode.org/reports/tr51/tr51-9.html",
+        "title": "Unicode Emoji 4.0",
+        "date": "22 November 2016",
+        "status": "Unicode Technical Report #51",
+        "publisher": "Unicode Consortium",
+        "obsoletedBy": [
+            "UTS51"
+        ]
+    },
+    "UTS10": {
+        "authors": [
+            "Mark Davis",
+            "Ken Whistler",
+            "Markus Scherer"
+        ],
+        "href": "https://www.unicode.org/reports/tr10/tr10-36.html",
+        "title": "Unicode Collation Algorithm",
+        "date": "16 June 2017",
+        "status": "Unicode Technical Standard #10",
+        "publisher": "Unicode Consortium"
+    },
+    "UTS22": {
+        "authors": [
+            "Mark Davis",
+            "Markus Scherer"
+        ],
+        "href": "https://www.unicode.org/reports/tr22/tr22-8.html",
+        "title": "Unicode Character Mapping Markup Language (CharmapML)",
+        "date": "31 May 2017",
+        "status": "Unicode Technical Standard #22",
+        "publisher": "Unicode Consortium"
+    },
+    "UTS46": {
+        "authors": [
+            "Mark Davis",
+            "Michel Suignard"
+        ],
+        "href": "https://www.unicode.org/reports/tr46/tr46-19.html",
+        "title": "Unicode IDNA Compatibility Processing",
+        "date": "8 June 2017",
+        "status": "Unicode Technical Standard #46",
+        "publisher": "Unicode Consortium"
+    },
+    "UTS51": {
+        "authors": [
+            "Mark Davis",
+            "Peter Edberg"
+        ],
+        "href": "https://www.unicode.org/reports/tr51/tr51-12.html",
+        "title": "Unicode Emoji",
+        "date": "18 May 2017",
+        "status": "Unicode Technical Standard #51",
+        "publisher": "Unicode Consortium"
+    }
+}

--- a/refs/unicode.json
+++ b/refs/unicode.json
@@ -1,11 +1,11 @@
 {
     "UAX11": {
         "authors": [
-            "Ken Lunde 小林劍"
+            "Ken Lunde 小林劍󠄁"
         ],
-        "href": "https://www.unicode.org/reports/tr11/tr11-33.html",
+        "href": "https://www.unicode.org/reports/tr11/tr11-36.html",
         "title": "East Asian Width",
-        "date": "14 May 2017",
+        "rawDate": "2019-01-25",
         "status": "Unicode Standard Annex #11",
         "publisher": "Unicode Consortium"
     },
@@ -13,20 +13,19 @@
         "authors": [
             "Andy Heninger"
         ],
-        "href": "https://www.unicode.org/reports/tr14/tr14-39.html",
+        "href": "https://www.unicode.org/reports/tr14/tr14-43.html",
         "title": "Unicode Line Breaking Algorithm",
-        "date": "12 June 2017",
+        "rawDate": "2019-02-15",
         "status": "Unicode Standard Annex #14",
         "publisher": "Unicode Consortium"
     },
     "UAX15": {
         "authors": [
-            "Mark Davis",
             "Ken Whistler"
         ],
-        "href": "https://www.unicode.org/reports/tr15/tr15-45.html",
+        "href": "https://www.unicode.org/reports/tr15/tr15-48.html",
         "title": "Unicode Normalization Forms",
-        "date": "26 May 2017",
+        "rawDate": "2019-02-04",
         "status": "Unicode Standard Annex #15",
         "publisher": "Unicode Consortium"
     },
@@ -45,12 +44,11 @@
     },
     "UAX24": {
         "authors": [
-            "Mark Davis",
             "Ken Whistler"
         ],
-        "href": "https://www.unicode.org/reports/tr24/tr24-27.html",
+        "href": "https://www.unicode.org/reports/tr24/tr24-29.html",
         "title": "Unicode Script Property",
-        "date": "26 May 2017",
+        "rawDate": "2019-02-06",
         "status": "Unicode Standard Annex #24",
         "publisher": "Unicode Consortium"
     },
@@ -73,34 +71,38 @@
     },
     "UAX29": {
         "authors": [
-            "Mark Davis",
-            "Laurențiu Iancu"
+            "Mark Davis"
         ],
-        "href": "https://www.unicode.org/reports/tr29/tr29-31.html",
+        "href": "https://www.unicode.org/reports/tr29/tr29-35.html",
         "title": "Unicode Text Segmentation",
-        "date": "13 June 2017",
+        "rawDate": "2019-02-15",
         "status": "Unicode Standard Annex #29",
         "publisher": "Unicode Consortium"
     },
     "UAX35": {
-        "authors": [
-            "Mark Davis",
-            "CLDR committee members"
-        ],
-        "href": "https://www.unicode.org/reports/tr35/tr35-47/tr35.html",
-        "title": "Unicode Locale Data Markup Language (LDML)",
-        "date": "15 March 2017",
-        "status": "Unicode Standard Annex #35",
-        "publisher": "Unicode Consortium"
+        "aliasOf": "UTS35"
     },
     "UAX44": {
         "authors": [
-            "Mark Davis",
-            "Ken Whistler"
+            "Ken Whistler",
+            "Laurențiu Iancu"
         ],
+        "href": "https://www.unicode.org/reports/tr44/tr44-24.html",
         "title": "Unicode Character Database",
-        "rawDate": "2013-09-25",
-        "href": "http://www.unicode.org/reports/tr44/"
+        "rawDate": "2019-02-27",
+        "status": "Unicode Standard Annex #44",
+        "publisher": "Unicode Consortium"
+    },
+    "UAX50": {
+        "authors": [
+            "Koji Ishii 石井宏治",
+            "Ken Lunde 小林劍󠄁"
+        ],
+        "href": "https://www.unicode.org/reports/tr50/tr50-22.html",
+        "title": "Unicode Vertical Text Layout",
+        "rawDate": "2019-02-04",
+        "status": "Unicode Standard Annex #50",
+        "publisher": "Unicode Consortium"
     },
     "UAX9": {
         "authors": [
@@ -108,11 +110,11 @@
             "Aharon Lanin",
             "Andrew Glass"
         ],
-        "href": "https://www.unicode.org/reports/tr9/tr9-37.html",
-        "publisher": "Unicode Consortium",
-        "date": "14 May 2017",
+        "href": "https://www.unicode.org/reports/tr9/tr9-41.html",
+        "title": "Unicode Bidirectional Algorithm",
+        "rawDate": "2019-02-04",
         "status": "Unicode Standard Annex #9",
-        "title": "Unicode Bidirectional Algorithm"
+        "publisher": "Unicode Consortium"
     },
     "UNICODE": {
         "href": "https://www.unicode.org/versions/latest/",
@@ -155,17 +157,7 @@
         "title": "BOCU-1: MIME-Compatible Unicode Compression"
     },
     "UTR24": {
-        "authors": [
-            "Mark Davis"
-        ],
-        "href": "https://www.unicode.org/unicode/reports/tr24/tr24-3.html",
-        "title": "Script Names",
-        "date": "27 September 2001",
-        "status": "Unicode Technical Report #24",
-        "publisher": "Unicode Consortium",
-        "obsoletedBy": [
-            "UAX24"
-        ]
+        "aliasOf": "UAX24"
     },
     "UTR26": {
         "authors": [
@@ -182,56 +174,29 @@
             "Mark Davis",
             "Michel Suignard"
         ],
-        "href": "https://www.unicode.org/reports/tr36/",
+        "href": "https://www.unicode.org/reports/tr36/tr36-15.html",
         "title": "Unicode Security Considerations",
-        "date": "19 September 2014",
+        "rawDate": "2014-09-19",
         "status": "Unicode Technical Report #36",
         "publisher": "Unicode Consortium"
     },
     "UTR39": {
-        "authors": [
-            "Mark Davis",
-            "Michel Suignard"
-        ],
-        "href": "https://www.unicode.org/reports/tr39/",
-        "title": "Unicode Security Mechanisms",
-        "date": "20 February 2019",
-        "status": "Unicode Technical Report #39",
-        "publisher": "Unicode Consortium"
+        "aliasOf": "UTS39"
     },
     "UTR50": {
-        "title": "Unicode Vertical Text Layout",
-        "authors": [
-            "Koji Ishii 石井宏治"
-        ],
-        "rawDate": "2016-11-23",
-        "href": "https://www.unicode.org/reports/tr50/tr50-17.html",
-        "status": "Unicode Technical Report #50",
-        "publisher": "Unicode Consortium"
+        "aliasOf": "UAX50"
     },
     "UTR51": {
-        "authors": [
-            "Mark Davis",
-            "Peter Edberg"
-        ],
-        "href": "https://www.unicode.org/reports/tr51/tr51-9.html",
-        "title": "Unicode Emoji 4.0",
-        "date": "22 November 2016",
-        "status": "Unicode Technical Report #51",
-        "publisher": "Unicode Consortium",
-        "obsoletedBy": [
-            "UTS51"
-        ]
+        "aliasOf": "UTS51"
     },
     "UTS10": {
         "authors": [
-            "Mark Davis",
             "Ken Whistler",
             "Markus Scherer"
         ],
-        "href": "https://www.unicode.org/reports/tr10/tr10-36.html",
+        "href": "https://www.unicode.org/reports/tr10/tr10-40.html",
         "title": "Unicode Collation Algorithm",
-        "date": "16 June 2017",
+        "rawDate": "2019-03-04",
         "status": "Unicode Technical Standard #10",
         "publisher": "Unicode Consortium"
     },
@@ -246,14 +211,36 @@
         "status": "Unicode Technical Standard #22",
         "publisher": "Unicode Consortium"
     },
+    "UTS35": {
+        "authors": [
+            "Mark Davis"
+        ],
+        "etAl": true,
+        "href": "https://www.unicode.org/reports/tr35/tr35-53/tr35.html",
+        "title": "Unicode Locale Data Markup Language (LDML)",
+        "rawDate": "2018-10-10",
+        "status": "Unicode Technical Standard #35",
+        "publisher": "Unicode Consortium"
+    },
+    "UTS39": {
+        "authors": [
+            "Mark Davis",
+            "Michel Suignard"
+        ],
+        "href": "https://www.unicode.org/reports/tr39/tr39-19.html",
+        "title": "Unicode Security Mechanisms",
+        "rawDate": "2019-02-20",
+        "status": "Unicode Technical Standard #39",
+        "publisher": "Unicode Consortium"
+    },
     "UTS46": {
         "authors": [
             "Mark Davis",
             "Michel Suignard"
         ],
-        "href": "https://www.unicode.org/reports/tr46/tr46-19.html",
+        "href": "https://www.unicode.org/reports/tr46/tr46-23.html",
         "title": "Unicode IDNA Compatibility Processing",
-        "date": "8 June 2017",
+        "rawDate": "2019-02-20",
         "status": "Unicode Technical Standard #46",
         "publisher": "Unicode Consortium"
     },
@@ -262,9 +249,9 @@
             "Mark Davis",
             "Peter Edberg"
         ],
-        "href": "https://www.unicode.org/reports/tr51/tr51-12.html",
+        "href": "https://www.unicode.org/reports/tr51/tr51-16.html",
         "title": "Unicode Emoji",
-        "date": "18 May 2017",
+        "rawDate": "2019-02-04",
         "status": "Unicode Technical Standard #51",
         "publisher": "Unicode Consortium"
     }

--- a/refs/unicode.json
+++ b/refs/unicode.json
@@ -57,11 +57,13 @@
     "UAX27": {
         "authors": [
             "Mark Davis",
-            "Michael Everson"
+            "Michael Everson",
+            "Asmus Freytag",
+            "John H. Jenkins"
         ],
         "etAl": true,
         "href": "https://www.unicode.org/unicode/reports/tr27/tr27-4.html",
-        "title": "Unicode 3.1.0",
+        "title": "Unicode 3.1",
         "date": "16 May 2001",
         "status": "Unicode Standard Annex #27",
         "publisher": "Unicode Consortium",
@@ -131,24 +133,26 @@
             "The Unicode Consortium"
         ],
         "title": "The Unicode Standard, Version 6.2.0",
-        "href": "http://www.unicode.org/versions/Unicode6.2.0/"
+        "href": "https://www.unicode.org/versions/Unicode6.2.0/"
     },
     "UTN22": {
         "authors": [
             "Elika J. Etemad"
         ],
         "title": "Robust Vertical Text Layout",
+        "status": "Unicode Technical Note #22",
         "rawDate": "2005-04-25",
-        "href": "http://unicode.org/notes/tn22/"
+        "href": "https://unicode.org/notes/tn22/"
     },
     "UTN6": {
         "authors": [
             "M. Scherer",
             "M. Davis"
         ],
+        "status": "Unicode Technical Note #6",
         "href": "https://www.unicode.org/notes/tn6/",
         "publisher": "Unicode Consortium",
-        "title": "UTN #6: BOCU-1: MIME-Compatible Unicode Compression"
+        "title": "BOCU-1: MIME-Compatible Unicode Compression"
     },
     "UTR24": {
         "authors": [
@@ -165,10 +169,12 @@
     },
     "UTR26": {
         "authors": [
-            "T. Phipps"
+            "Rick McGowan"
         ],
-        "href": "https://www.unicode.org/reports/tr26/",
-        "title": "UTR #26: Compatibility Encoding Scheme For UTF-16: 8-BIT (CESU-8)",
+        "href": "https://www.unicode.org/reports/tr26/tr26-4.html",
+        "title": "Compatibility Encoding Scheme for UTF-16: 8-Bit (CESU-8)",
+        "rawDate": "2011-12-19",
+        "status": "Unicode Technical Report #26",
         "publisher": "Unicode Consortium"
     },
     "UTR36": {
@@ -194,12 +200,14 @@
         "publisher": "Unicode Consortium"
     },
     "UTR50": {
-        "title": "Unicode Properties for Vertical Text Layout",
+        "title": "Unicode Vertical Text Layout",
         "authors": [
-            "Koji Ishii"
+            "Koji Ishii 石井宏治"
         ],
-        "rawDate": "2013-08-31",
-        "href": "http://www.unicode.org/reports/tr50/"
+        "rawDate": "2016-11-23",
+        "href": "https://www.unicode.org/reports/tr50/tr50-17.html",
+        "status": "Unicode Technical Report #50",
+        "publisher": "Unicode Consortium"
     },
     "UTR51": {
         "authors": [
@@ -233,7 +241,7 @@
             "Markus Scherer"
         ],
         "href": "https://www.unicode.org/reports/tr22/tr22-8.html",
-        "title": "Unicode Character Mapping Markup Language (CharmapML)",
+        "title": "Unicode Character Mapping Markup Language (CharMapML)",
         "date": "31 May 2017",
         "status": "Unicode Technical Standard #22",
         "publisher": "Unicode Consortium"

--- a/refs/unicode.json
+++ b/refs/unicode.json
@@ -79,8 +79,61 @@
         "status": "Unicode Standard Annex #29",
         "publisher": "Unicode Consortium"
     },
+    "UAX31": {
+        "authors": [
+            "Mark Davis"
+        ],
+        "href": "https://www.unicode.org/reports/tr31/tr31-31.html",
+        "title": "Unicode Identifier and Pattern Syntax",
+        "rawDate": "2019-02-19",
+        "status": "Unicode Standard Annex #31",
+        "publisher": "Unicode Consortium"
+    },
+    "UAX34": {
+        "authors": [
+            "Addison Phillips"
+        ],
+        "href": "https://www.unicode.org/reports/tr34/tr34-25.html",
+        "title": "Unicode Named Character Sequences",
+        "rawDate": "2019-02-19",
+        "status": "Unicode Standard Annex #34",
+        "publisher": "Unicode Consortium"
+    },
     "UAX35": {
         "aliasOf": "UTS35"
+    },
+    "UAX38": {
+        "authors": [
+            "John H. Jenkins 井作恆",
+            "Richard Cook 曲理查",
+            "Ken Lunde 小林劍󠄁"
+        ],
+        "href": "https://www.unicode.org/reports/tr38/tr38-27.html",
+        "title": "Unicode Han Database (Unihan)",
+        "rawDate": "2019-02-15",
+        "status": "Unicode Standard Annex #38",
+        "publisher": "Unicode Consortium"
+    },
+    "UAX41": {
+        "authors": [
+            "Laurențiu Iancu",
+            "Rick McGowan"
+        ],
+        "href": "https://www.unicode.org/reports/tr41/tr41-24.html",
+        "title": "Common References for Unicode Standard Annexes",
+        "rawDate": "2019-02-08",
+        "status": "Unicode Standard Annex #41",
+        "publisher": "Unicode Consortium"
+    },
+    "UAX42": {
+        "authors": [
+            "Eric Muller"
+        ],
+        "href": "https://www.unicode.org/reports/tr42/tr42-25.html",
+        "title": "Unicode Character Database in XML",
+        "rawDate": "2019-03-01",
+        "status": "Unicode Standard Annex #42",
+        "publisher": "Unicode Consortium"
     },
     "UAX44": {
         "authors": [
@@ -91,6 +144,16 @@
         "title": "Unicode Character Database",
         "rawDate": "2019-02-27",
         "status": "Unicode Standard Annex #44",
+        "publisher": "Unicode Consortium"
+    },
+    "UAX45": {
+        "authors": [
+            "John H. Jenkins 井作恆"
+        ],
+        "href": "https://www.unicode.org/reports/tr45/tr45-21.html",
+        "title": "U-source Ideographs",
+        "rawDate": "2019-02-15",
+        "status": "Unicode Standard Annex #45",
         "publisher": "Unicode Consortium"
     },
     "UAX50": {
@@ -156,8 +219,43 @@
         "publisher": "Unicode Consortium",
         "title": "BOCU-1: MIME-Compatible Unicode Compression"
     },
+    "UTR17": {
+        "authors": [
+            "Ken Whistler",
+            "Mark Davis",
+            "Asmus Freytag"
+        ],
+        "href": "https://www.unicode.org/reports/tr17/tr17-7.html",
+        "title": "Unicode Character Encoding Model",
+        "rawDate": "2008-11-11",
+        "status": "Unicode Technical Report #17",
+        "publisher": "Unicode Consortium"
+    },
+    "UTR23": {
+        "authors": [
+            "Ken Whistler",
+            "Asmus Freytag"
+        ],
+        "href": "https://www.unicode.org/reports/tr23/tr23-11.html",
+        "title": "The Unicode Character Property Model",
+        "rawDate": "2015-05-27",
+        "status": "Unicode Technical Report #23",
+        "publisher": "Unicode Consortium"
+    },
     "UTR24": {
         "aliasOf": "UAX24"
+    },
+    "UTR25": {
+        "authors": [
+            "Barbara Beeton",
+            "Asmus Freytag",
+            "Murray Sargent III"
+        ],
+        "href": "https://www.unicode.org/reports/tr25/tr25-15.pdf",
+        "title": "Unicode Support for Mathematics",
+        "rawDate": "2017-05-30",
+        "status": "Unicode Technical Report #25",
+        "publisher": "Unicode Consortium"
     },
     "UTR26": {
         "authors": [
@@ -167,6 +265,17 @@
         "title": "Compatibility Encoding Scheme for UTF-16: 8-Bit (CESU-8)",
         "rawDate": "2011-12-19",
         "status": "Unicode Technical Report #26",
+        "publisher": "Unicode Consortium"
+    },
+    "UTR33": {
+        "authors": [
+            "Ken Whistler",
+            "Asmus Freytag"
+        ],
+        "href": "https://www.unicode.org/reports/tr33/tr33-5.html",
+        "title": "Unicode Conformance Model",
+        "rawDate": "2008-11-11",
+        "status": "Unicode Technical Report #33",
         "publisher": "Unicode Consortium"
     },
     "UTR36": {
@@ -189,6 +298,18 @@
     "UTR51": {
         "aliasOf": "UTS51"
     },
+    "UTR53": {
+        "authors": [
+            "Roozbeh Pournader",
+            "Bob Hallissy",
+            "Lorna Evans"
+        ],
+        "href": "https://www.unicode.org/reports/tr53/tr53-4.html",
+        "title": "Unicode Arabic Mark Rendering",
+        "rawDate": "2018-10-02",
+        "status": "Unicode Technical Report #53",
+        "publisher": "Unicode Consortium"
+    },
     "UTS10": {
         "authors": [
             "Ken Whistler",
@@ -198,6 +319,17 @@
         "title": "Unicode Collation Algorithm",
         "rawDate": "2019-03-04",
         "status": "Unicode Technical Standard #10",
+        "publisher": "Unicode Consortium"
+    },
+    "UTS18": {
+        "authors": [
+            "Mark Davis",
+            "Andy Heninger"
+        ],
+        "href": "https://www.unicode.org/reports/tr18/tr18-19.html",
+        "title": "Unicode Regular Expressions",
+        "rawDate": "2016-10-18",
+        "status": "Unicode Technical Standard #18",
         "publisher": "Unicode Consortium"
     },
     "UTS22": {
@@ -220,6 +352,17 @@
         "title": "Unicode Locale Data Markup Language (LDML)",
         "rawDate": "2018-10-10",
         "status": "Unicode Technical Standard #35",
+        "publisher": "Unicode Consortium"
+    },
+    "UTS37": {
+        "authors": [
+            "Ken Lunde 小林劍󠄁",
+            "Richard Cook 曲理查"
+        ],
+        "href": "https://www.unicode.org/reports/tr37/tr37-12.html",
+        "title": "Unicode Ideographic Variation Database",
+        "rawDate": "2018-01-29",
+        "status": "Unicode Technical Standard #37",
         "publisher": "Unicode Consortium"
     },
     "UTS39": {

--- a/scripts/unicode.js
+++ b/scripts/unicode.js
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+'use strict';
+const async = require('async');
+const { JSDOM } = require('jsdom');
+const request = require('request');
+const userAgent = require("./user-agent");
+const helper = require('./helper');
+
+const FILENAME = "unicode.json";
+const current = helper.readBiblio(FILENAME);
+
+const reportsToFetch = [
+    9,
+    10,
+    11,
+    14,
+    15,
+    24,
+    29,
+    35,
+    36,
+    39,
+    44,
+    46,
+    50,
+    51,
+];
+
+async.each(reportsToFetch, (num, cb) => {
+    const url = `https://www.unicode.org/reports/tr${num}/`;
+    console.log('Fetching', url, '...');
+    request({
+        url,
+        headers: {
+            'User-Agent': userAgent()
+        }
+    }, (err, response, body) => {
+        if (err || response.statusCode !== 200) {
+            console.log("Can't fetch", url);
+            cb();
+            return;
+        }
+        console.log('Parsing', url, '...');
+        const dom = new JSDOM(body, { url });
+        const { document } = dom.window;
+        const type = document.title.slice(0, 3);
+        if (type !== 'UTS' && type !== 'UTR' && type !== 'UAX') {
+            console.log('Unable to parse title', document.title);
+            cb();
+            return;
+        }
+        const id = type + num;
+        const statusEl = document.querySelector('.body > h2');
+        if (!statusEl) {
+            console.log('Unable to find status');
+            cb();
+            return;
+        }
+        const status = trimText(statusEl.textContent);
+
+        const titleEl = statusEl.nextElementSibling;
+        if (!titleEl || titleEl.tagName !== 'H1') {
+            console.log('Unable to find title');
+            cb();
+            return;
+        }
+        let title = trimText(titleEl.textContent);
+        if (!/[a-z]/.test(title))
+            title = titleCase(title);
+
+        const infoTableEl = document.querySelector('.body > table');
+        const infoTable = infoTableEl && parseTable(infoTableEl);
+        if (!infoTable) {
+            console.log('Unable to find information table');
+            cb();
+            return;
+        }
+
+        const date = trimText(infoTable.Date);
+        if (!date) {
+            console.log('Unable to find date in table');
+            cb();
+            return;
+        }
+        let isRawDate = /\d{4}-\d{2}-\d{2}/.test(date);
+
+        const href = processURL(infoTable['This Version'] || url);
+
+        const authors = infoTable.Editor && parseEditor(infoTable.Editor);
+        if (!authors) {
+            console.log('Unable to find/parse editors in table');
+            cb();
+            return;
+        }
+
+        if (type !== 'UAX' && current[`UAX${num}`])
+            current[`UAX${num}`] = { aliasOf: id };
+        if (type !== 'UTR' && current[`UTR${num}`])
+            current[`UTR${num}`] = { aliasOf: id };
+        if (type !== 'UTS' && current[`UTS${num}`])
+            current[`UTS${num}`] = { aliasOf: id };
+
+        current[id] = {
+            authors,
+            etAl: authors.etAl,
+            href,
+            title,
+            date: isRawDate ? undefined : date,
+            rawDate: isRawDate ? date : undefined,
+            status,
+            publisher: 'Unicode Consortium'
+        };
+        cb();
+    });
+}, (err) => {
+    if (err) {
+        console.log('there was an error');
+        console.error(err);
+        return;
+    }
+    const output = {};
+    for (const key of Object.keys(current).sort()) {
+        output[key] = current[key];
+    }
+    helper.writeBiblio(FILENAME, output);
+});
+
+function* range(from, until) {
+    for (let i = from; i <= until; i++)
+        yield i;
+}
+
+function trimText(str) {
+    return str.replace(/®/g, '').trim().replace(/\s+/g, ' ');
+}
+
+function titleCase(str) {
+    return str.replace(/(\w)(\S*)/g, (_, first, rest) => first.toUpperCase() + rest.toLowerCase());
+}
+
+function gatherText(element) {
+    let str = '';
+    for (const node of element.childNodes) {
+        if (node.nodeType === node.ELEMENT_NODE && node.tagName === 'BR')
+            str += '\n';
+        else
+            str += trimText(node.textContent) + ' ';
+    }
+    return str;
+}
+
+function parseTable(tableEl) {
+    const obj = {};
+    for (const rowEl of tableEl.querySelectorAll('tr')) {
+        if (rowEl.cells.length !== 2)
+            return null;
+        let key = trimText(rowEl.cells[0].textContent);
+        if (key === 'Editors' || key === 'Author' || key === 'Authors')
+            key = 'Editor';
+        obj[key] = gatherText(rowEl.cells[1]);
+    }
+    return obj;
+}
+
+function processURL(str) {
+    return trimText(str).replace(/^http:/, 'https:');
+}
+
+function parseEditor(str) {
+    const arr = str.split(/\n|,|\band\b/g).map(ed => trimText(ed.replace(/\(.*/, ''))).filter(Boolean);
+    if (/\bother\b/.test(arr[arr.length - 1])) {
+        arr.pop();
+        arr.etAl = true;
+    }
+    return arr;
+}

--- a/scripts/unicode.js
+++ b/scripts/unicode.js
@@ -9,24 +9,34 @@ const helper = require('./helper');
 const FILENAME = "unicode.json";
 const current = helper.readBiblio(FILENAME);
 
-const reportsToFetch = [
-    9,
-    10,
-    11,
-    14,
-    15,
-    24,
-    29,
-    35,
-    36,
-    39,
-    44,
-    46,
-    50,
-    51,
-];
+const MAX_REPORT = 53;
+const skip = new Set([
+    // Stabilized
+    6, 16, 22, 26,
 
-async.each(reportsToFetch, (num, cb) => {
+    // Old versions of Unicode
+    4, 8, 27, 28,
+
+    // Other superseded
+    1, 2, 3, 5, 7, 13, 19, 21,
+
+    // Withdrawn or suspended
+    12, 20, 30, 32, 40, 47, 49, 52,
+
+    // Nonexistent
+    43, 48,
+
+    // Not in HTML
+    25,
+]);
+
+async.each(range(1, MAX_REPORT), (num, cb) => {
+    if (skip.has(num)) {
+        console.log('Skipping report #' + num);
+        cb();
+        return;
+    }
+
     const url = `https://www.unicode.org/reports/tr${num}/`;
     console.log('Fetching', url, '...');
     request({

--- a/scripts/update-all
+++ b/scripts/update-all
@@ -41,6 +41,7 @@ function run()
     node "./scripts/ietf.js" &&
     node "./scripts/w3c.js" &&
     node "./scripts/csswg.js" &&
+    node "./scripts/unicode.js" &&
     node "./scripts/fetch-refs.js" "https://resources.whatwg.org/biblio.json" "WHATWG" &&
     node "./scripts/fetch-refs.js" "https://wicg.github.io/admin/biblio.json" "WICG" &&
     node "./scripts/fetch-refs.js" "https://wg21.link/index.json" "WG21" &&


### PR DESCRIPTION
Provide script to update Unicode Technical Reports automatically. Add missing TRs. Update TR status (UTR vs. UAX/UTS) in a backwards-compatible way (using aliases).