### PR TITLE
Added geospatial standards and other specifications from the OGC

### DIFF
--- a/refs/ogc.json
+++ b/refs/ogc.json
@@ -1,0 +1,10264 @@
+{
+    "ogc-00-028": {
+        "authors": [
+            "Allan Doyle"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=7196", 
+        "ogcNumber": "00-028", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2000-04-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Map Service"
+    }, 
+    "ogc-00-029": {
+        "authors": [
+            "Ron Lake"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=7197", 
+        "ogcNumber": "00-029", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2000-05-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Geography Markup Language"
+    }, 
+    "ogc-00-106": {
+        "authors": [
+            "Cliff Kottman", 
+            "Charles Roswell"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=7198", 
+        "ogcNumber": "00-106", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2000-04-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 6 - The Coverage Type"
+    }, 
+    "ogc-00-115": {
+        "authors": [
+            "Cliff Kottman", 
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=7199", 
+        "ogcNumber": "00-115", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2000-04-24", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 15 - Image Exploitation Services"
+    }, 
+    "ogc-00-116": {
+        "authors": [
+            "Cliff Kottman", 
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=7200", 
+        "ogcNumber": "00-116", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2000-04-24", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 16 - Image Coordinate Transformation Services"
+    }, 
+    "ogc-00-117": {
+        "authors": [
+            "Cliff Kottman"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=988", 
+        "ogcNumber": "00-117", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2000-05-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 17 - Location Based Mobile Services"
+    }, 
+    "ogc-01-004": {
+        "authors": [
+            "Louis Burry"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=6628", 
+        "ogcNumber": "01-004", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2001-01-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Grid Coverage Service Implementation Specification"
+    }, 
+    "ogc-01-009": {
+        "authors": [
+            "Martin Daly"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=999", 
+        "ogcNumber": "01-009", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2001-01-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Coordinate Transformation Service Implementation Specification"
+    }, 
+    "ogc-01-013r1": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1006", 
+        "ogcNumber": "01-013r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2001-02-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "High-Level Ground Coordinate Transformation Interface"
+    }, 
+    "ogc-01-014r5": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1012", 
+        "ogcNumber": "01-014r5", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2001-10-10", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "CT Definition Data for Coordinate Reference"
+    }, 
+    "ogc-01-019": {
+        "authors": [
+            "John Evans"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1020", 
+        "ogcNumber": "01-019", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2001-02-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "XML for Image and map Annotation"
+    }, 
+    "ogc-01-022r1": {
+        "authors": [
+            "Jeff de La Beaujardiere"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1024", 
+        "ogcNumber": "01-022r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2001-05-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Basic Services Model"
+    }, 
+    "ogc-01-024r1": {
+        "authors": [
+            "Louis Reich"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1028", 
+        "ogcNumber": "01-024r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2001-01-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Registry Server"
+    }, 
+    "ogc-01-026r1": {
+        "authors": [
+            "Serge Margoulies"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1031", 
+        "ogcNumber": "01-026r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2001-03-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Geocoder"
+    }, 
+    "ogc-01-029": {
+        "authors": [
+            "Ron Lake"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1034", 
+        "ogcNumber": "01-029", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2001-02-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Geography Markup Language"
+    }, 
+    "ogc-01-035": {
+        "authors": [
+            "Jeff Lansing"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1040", 
+        "ogcNumber": "01-035", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2001-03-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Geoparser"
+    }, 
+    "ogc-01-036": {
+        "authors": [
+            "Rob Atkinson"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1041", 
+        "ogcNumber": "01-036", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2001-03-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Gazetteer"
+    }, 
+    "ogc-01-037": {
+        "authors": [
+            "Ron Lake"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1042", 
+        "ogcNumber": "01-037", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2001-03-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Location Organizer Folder"
+    }, 
+    "ogc-01-042": {
+        "authors": [
+            "Tom Strickland"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1046", 
+        "ogcNumber": "01-042", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2001-10-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic Domain 1 - Telecommunications Domain"
+    }, 
+    "ogc-01-044r2": {
+        "authors": [
+            "John Bobbitt"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1050", 
+        "ogcNumber": "01-044r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2001-06-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Units of Measure and Quantity Datatypes"
+    }, 
+    "ogc-01-047r2": {
+        "authors": [
+            "Jeff de La Beaujardiere"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1058", 
+        "ogcNumber": "01-047r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2001-06-21", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Map Service"
+    }, 
+    "ogc-01-061": {
+        "authors": [
+            "Raj Singh"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1072", 
+        "ogcNumber": "01-061", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2001-08-24", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Terrain Server"
+    }, 
+    "ogc-01-068r3": {
+        "authors": [
+            "Jeff de La Beaujardiere"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1081&format=pdf", 
+        "ogcNumber": "01-068r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2002-04-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Map Service"
+    }, 
+    "ogc-01-101": {
+        "authors": [
+            "John Herring"
+        ], 
+        "href": "https://www.iso.org/standard/26012.html", 
+        "ogcNumber": "01-101", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2001-05-10", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 1 - Feature Geometry"
+    }, 
+    "ogc-01-111": {
+        "authors": [
+            "ISO"
+        ], 
+        "href": "http://www.iso.org/iso/en/CatalogueDetailPage.CatalogueDetail?CSNUMBER=26020", 
+        "ogcNumber": "01-111", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2001-06-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 11 - Metadata"
+    }, 
+    "ogc-02-007r4": {
+        "authors": [
+            "John Bobbitt"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=11498", 
+        "ogcNumber": "02-007r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2002-08-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Units of Measure Recommendation"
+    }, 
+    "ogc-02-009": {
+        "authors": [
+            "Ron Lake"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1108", 
+        "ogcNumber": "02-009", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2002-01-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Geography Markup Language"
+    }, 
+    "ogc-02-017r1": {
+        "authors": [
+            "Jeff de La Beaujardiere"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1118", 
+        "ogcNumber": "02-017r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2002-08-24", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "WMS Part 2: XML for Requests using HTTP Post"
+    }, 
+    "ogc-02-019r1": {
+        "authors": [
+            "Jeff Lansing"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1121", 
+        "ogcNumber": "02-019r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2002-02-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Coverage Portrayal Service"
+    }, 
+    "ogc-02-023r4": {
+        "authors": [
+            "Simon Cox", 
+            "Paul Daisey", 
+            "Ron Lake", 
+            "Clemens Portele", 
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=7174", 
+        "ogcNumber": "02-023r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-01-29", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Geography Markup Language (GML) Encoding Specification"
+    }, 
+    "ogc-02-024": {
+        "authors": [
+            "John Evans"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1131", 
+        "ogcNumber": "02-024", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2002-06-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Coverage Service"
+    }, 
+    "ogc-02-026r1": {
+        "authors": [
+            "Mike Botts"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1133", 
+        "ogcNumber": "02-026r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2002-04-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "SensorML"
+    }, 
+    "ogc-02-026r4": {
+        "authors": [
+            "Mike Botts"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=11516", 
+        "ogcNumber": "02-026r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2002-12-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Sensor Model Language (SensorML) for In-situ and Remote Sensors"
+    }, 
+    "ogc-02-027": {
+        "authors": [
+            "Simon Cox"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1137", 
+        "ogcNumber": "02-027", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2002-05-31", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Observations and Measurements"
+    }, 
+    "ogc-02-028": {
+        "authors": [
+            "Tom  McCarty"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1141", 
+        "ogcNumber": "02-028", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2002-04-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Sensor Collection Service"
+    }, 
+    "ogc-02-039r1": {
+        "authors": [
+            "Roland Wagner"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=11500", 
+        "ogcNumber": "02-039r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2002-10-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Pricing and Ordering"
+    }, 
+    "ogc-02-058": {
+        "authors": [
+            "Peter Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=7176", 
+        "ogcNumber": "02-058", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2002-05-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Feature Service"
+    }, 
+    "ogc-02-059": {
+        "authors": [
+            "Peter Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1171", 
+        "ogcNumber": "02-059", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2001-05-01", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Filter Encoding"
+    }, 
+    "ogc-02-061r1": {
+        "authors": [
+            "Andreas Poth", 
+            "Markus Muller"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1174", 
+        "ogcNumber": "02-061r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2002-09-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Coordinate Transformation Service"
+    }, 
+    "ogc-02-066r1": {
+        "authors": [
+            "Jean-Philippe Humblet"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1181", 
+        "ogcNumber": "02-066r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2002-08-29", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Map Context Documents"
+    }, 
+    "ogc-02-069": {
+        "authors": [
+            "Ron Lake"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=11339", 
+        "ogcNumber": "02-069", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2002-08-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Geography Markup Language"
+    }, 
+    "ogc-02-070": {
+        "authors": [
+            "Bill Lalonde"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1188", 
+        "ogcNumber": "02-070", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2002-08-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Styled Layer Descriptor (SLD) Implementation Specification"
+    }, 
+    "ogc-02-087r3": {
+        "authors": [
+            "Doug Nebert"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=3843", 
+        "ogcNumber": "02-087r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2002-12-13", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Catalog Interface"
+    }, 
+    "ogc-02-102": {
+        "authors": [
+            "Roel Nicolai"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1220", 
+        "ogcNumber": "02-102", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2002-03-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 2 - Spatial Referencing by Coordinates"
+    }, 
+    "ogc-02-112": {
+        "authors": [
+            "ISO"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1221", 
+        "ogcNumber": "02-112", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2001-09-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 12 - The OpenGIS Service Architecture"
+    }, 
+    "ogc-03-002r8": {
+        "authors": [
+            "Craig Bruce"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1386", 
+        "ogcNumber": "03-002r8", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-05-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Binary-XML Encoding Specification"
+    }, 
+    "ogc-03-002r9": {
+        "authors": [
+            "Craig Bruce"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=13636", 
+        "ogcNumber": "03-002r9", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-01-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Binary Extensible Markup Language (BXML) Encoding Specification"
+    }, 
+    "ogc-03-003r10": {
+        "authors": [
+            "Peter Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=4347", 
+        "ogcNumber": "03-003r10", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-05-10", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Level 0 Profile of GML3 for WFS"
+    }, 
+    "ogc-03-006r1": {
+        "authors": [
+            "Marwa Mabrouk"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=3839", 
+        "ogcNumber": "03-006r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-06-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Location Services (OpenLS): Core Services [Parts 1-5]"
+    }, 
+    "ogc-03-006r3": {
+        "authors": [
+            "Marwa Mabrouk"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=3418", 
+        "ogcNumber": "03-006r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-01-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Location Services (OpenLS): Core Services [Parts 1-5]"
+    }, 
+    "ogc-03-007r1": {
+        "authors": [
+            "Tom Bychowski"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=3840", 
+        "ogcNumber": "03-007r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-06-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Location Services (OpenLS): Navigation Service [Part 6]"
+    }, 
+    "ogc-03-008r2": {
+        "authors": [
+            "Ingo Simonis", 
+            "Andreas Wytzisk"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1367", 
+        "ogcNumber": "03-008r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-04-21", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Notification Service"
+    }, 
+    "ogc-03-010r7": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1345", 
+        "ogcNumber": "03-010r7", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-05-21", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Recommended XML Encoding of CRS Definitions"
+    }, 
+    "ogc-03-010r9": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=11517", 
+        "ogcNumber": "03-010r9", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-10-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Recommended XML Encoding of CRS Definitions"
+    }, 
+    "ogc-03-013": {
+        "authors": [
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1338", 
+        "ogcNumber": "03-013", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-01-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Object Service Implementation Specification"
+    }, 
+    "ogc-03-014": {
+        "authors": [
+            "J"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1337", 
+        "ogcNumber": "03-014", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-01-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Web Services SOAP Experiment Report"
+    }, 
+    "ogc-03-021": {
+        "authors": [
+            "Jeff Yutzler"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1328", 
+        "ogcNumber": "03-021", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-01-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Integrated Client for Multiple OGC-compliant Services"
+    }, 
+    "ogc-03-022r3": {
+        "authors": [
+            "Simon Cox"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1324", 
+        "ogcNumber": "03-022r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-02-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Observations and Measurements"
+    }, 
+    "ogc-03-025": {
+        "authors": [
+            "Josh Lieberman"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1320", 
+        "ogcNumber": "03-025", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-01-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Services Architecture"
+    }, 
+    "ogc-03-026": {
+        "authors": [
+            "Joshua Lieberman"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1319", 
+        "ogcNumber": "03-026", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-01-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Service Information Model"
+    }, 
+    "ogc-03-028": {
+        "authors": [
+            "Josh Lieberman", 
+            "Lou Reich", 
+            "Peter Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1317", 
+        "ogcNumber": "03-028", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-01-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Web Services UDDI Experiment"
+    }, 
+    "ogc-03-029": {
+        "authors": [
+            "Stephane Fellah", 
+            "Steven Keens"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1315", 
+        "ogcNumber": "03-029", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-01-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS Messaging Framework"
+    }, 
+    "ogc-03-031": {
+        "authors": [
+            "William Lalonde"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1313", 
+        "ogcNumber": "03-031", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-01-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Style Management Service"
+    }, 
+    "ogc-03-036": {
+        "authors": [
+            "Jean-Philippe Humblet"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1306", 
+        "ogcNumber": "03-036", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-01-21", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Map Context Documents"
+    }, 
+    "ogc-03-036r2": {
+        "authors": [
+            "Jean-Philippe Humblet"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=3841", 
+        "ogcNumber": "03-036r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-06-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Map Context Documents"
+    }, 
+    "ogc-03-040": {
+        "authors": [
+            "George Percivall"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=3836", 
+        "ogcNumber": "03-040", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-09-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Reference Model"
+    }, 
+    "ogc-03-053r1": {
+        "authors": [
+            "Carl Reed", 
+            "George Percivall"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=3835", 
+        "ogcNumber": "03-053r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-05-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Technical Document Baseline"
+    }, 
+    "ogc-03-055r1": {
+        "authors": [
+            "Louis Rose"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1282", 
+        "ogcNumber": "03-055r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-06-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Critical Infrastructure Collaborative Environment Architecture: Engineering Viewpoint"
+    }, 
+    "ogc-03-061": {
+        "authors": [
+            "Geoffrey Ehler"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1273", 
+        "ogcNumber": "03-061", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-05-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Critical Infrastructure Collaborative Environment Architecture: Enterprise Viewpoint"
+    }, 
+    "ogc-03-062r1": {
+        "authors": [
+            "Richard Martell"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1271", 
+        "ogcNumber": "03-062r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-06-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Critical Infrastructure Collaborative Environment Architecture: Information Viewpoint"
+    }, 
+    "ogc-03-063r1": {
+        "authors": [
+            "Joshua Lieberman"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1269", 
+        "ogcNumber": "03-063r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-06-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Critical Infrastructure Collaborative Environment Architecture: Computational Viewpoint"
+    }, 
+    "ogc-03-064r1": {
+        "authors": [
+            "Phillip C. Dibner"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=1267", 
+        "ogcNumber": "03-064r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-06-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GO-1 Application Objects Report"
+    }, 
+    "ogc-03-064r10": {
+        "authors": [
+            "Greg Reynolds"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=10378", 
+        "ogcNumber": "03-064r10", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-05-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Geographic Objects Implementation Specification *RETIRED*"
+    }, 
+    "ogc-03-064r5": {
+        "authors": [
+            "Eric Bertel"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=5936", 
+        "ogcNumber": "03-064r5", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-06-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GO-1 Application Objects"
+    }, 
+    "ogc-03-065r6": {
+        "authors": [
+            "John Evans"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=3837", 
+        "ogcNumber": "03-065r6", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-10-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Web Coverage Service (WCS) Implementation Specification"
+    }, 
+    "ogc-03-073r1": {
+        "authors": [
+            "Roel Nicolai"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=11518", 
+        "ogcNumber": "03-073r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-10-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 2 - Spatial Referencing by Coordinates"
+    }, 
+    "ogc-03-081r2": {
+        "authors": [
+            "Joshua Lieberman"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=11499", 
+        "ogcNumber": "03-081r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-11-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Web Terrain Service RFC"
+    }, 
+    "ogc-03-088r1": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=11519", 
+        "ogcNumber": "03-088r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2003-10-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Web Services Common"
+    }, 
+    "ogc-03-088r6": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=4550", 
+        "ogcNumber": "03-088r6", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-01-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Web Services Common"
+    }, 
+    "ogc-03-105r1": {
+        "authors": [
+            "Simon Cox", 
+            "Paul Daisey", 
+            "Ron Lake", 
+            "Clemens Portele", 
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=4700", 
+        "ogcNumber": "03-105r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-04-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Geography Markup Language (GML) Encoding Specification"
+    }, 
+    "ogc-03-109r1": {
+        "authors": [
+            "Jeff de La Beaujardiere"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=4756", 
+        "ogcNumber": "03-109r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-02-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Map Service"
+    }, 
+    "ogc-04-010r1": {
+        "authors": [
+            "Peter Schut"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=5858", 
+        "ogcNumber": "04-010r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-05-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Geolinked Data Access Service"
+    }, 
+    "ogc-04-011r1": {
+        "authors": [
+            "Peter Schut"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=5859", 
+        "ogcNumber": "04-011r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-05-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Geolinking Service"
+    }, 
+    "ogc-04-013r4": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=6944", 
+        "ogcNumber": "04-013r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-09-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "A URN namespace for the Open Geospatial Consortium (OGC)"
+    }, 
+    "ogc-04-014r1": {
+        "authors": [
+            "Carl Reed", 
+            "George Percivall"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=5393", 
+        "ogcNumber": "04-014r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-04-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Technical Document Baseline"
+    }, 
+    "ogc-04-016r3": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=6324", 
+        "ogcNumber": "04-016r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-06-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS Common Recomendation Paper"
+    }, 
+    "ogc-04-017r1": {
+        "authors": [
+            "Richard Martell"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=7048", 
+        "ogcNumber": "04-017r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-10-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Catalogue Services - ebRIM (ISO/TS 15000-3) profile of CSW"
+    }, 
+    "ogc-04-019r2": {
+        "authors": [
+            "Mike Botts"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=7927", 
+        "ogcNumber": "04-019r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-11-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Sensor Model Language (SensorML) for In-situ and Remote Sensors"
+    }, 
+    "ogc-04-021r3": {
+        "authors": [
+            "Doug Nebert"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=5929", 
+        "ogcNumber": "04-021r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-08-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Catalogue Service Implementation Specification [Catalogue Service for the Web]"
+    }, 
+    "ogc-04-038r1": {
+        "authors": [
+            "Uwe Voges", 
+            "Kristian Senkler"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=6495", 
+        "ogcNumber": "04-038r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-10-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "ISO19115/ISO19119 Application Profile for CSW 2.0"
+    }, 
+    "ogc-04-038r2": {
+        "authors": [
+            "Uwe Voges", 
+            "Kristian Senkler"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=8305", 
+        "ogcNumber": "04-038r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-04-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "ISO19115/ISO19119 Application Profile for CSW 2.0 (CAT2 AP ISO19115/19)"
+    }, 
+    "ogc-04-039": {
+        "authors": [
+            "Louis Rose"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=6669", 
+        "ogcNumber": "04-039", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-09-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Geospatial Portal Reference Architecture"
+    }, 
+    "ogc-04-040": {
+        "authors": [
+            "Bill Lalonde"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=7470", 
+        "ogcNumber": "04-040", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-02-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Style Management Services for Emergency Mapping Symbology"
+    }, 
+    "ogc-04-046r3": {
+        "authors": [
+            "Roger Lott"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=6716", 
+        "ogcNumber": "04-046r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-02-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 2 - Spatial Referencing by Coordinates"
+    }, 
+    "ogc-04-049r1": {
+        "authors": [
+            "Philippe Duschene", 
+            "Jerome Sonnet"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=9540", 
+        "ogcNumber": "04-049r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-04-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "WCS Change Request: Support for WSDL & SOAP"
+    }, 
+    "ogc-04-050r1": {
+        "authors": [
+            "Philippe Duschene", 
+            "Jerome Sonnet"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=9541", 
+        "ogcNumber": "04-050r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-04-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "WMS Change Request: Support for WSDL & SOAP"
+    }, 
+    "ogc-04-051": {
+        "authors": [
+            "George Percivall"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=6621", 
+        "ogcNumber": "04-051", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-09-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS1.2 Image Handling Design"
+    }, 
+    "ogc-04-052": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=6660", 
+        "ogcNumber": "04-052", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-09-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS1.2 Image Handling Requirements"
+    }, 
+    "ogc-04-060r1": {
+        "authors": [
+            "Jerome Sonnett"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=8348", 
+        "ogcNumber": "04-060r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-02-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS 2 Common Architecture: WSDL SOAP UDDI"
+    }, 
+    "ogc-04-071": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=7257", 
+        "ogcNumber": "04-071", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-10-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Some image geometry models"
+    }, 
+    "ogc-04-084": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=7560", 
+        "ogcNumber": "04-084", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-06-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 0 - Overview"
+    }, 
+    "ogc-04-085": {
+        "authors": [
+            "Richard Creps", 
+            "Victor Brown", 
+            "Bill Floyd", 
+            "John Garcia", 
+            "Jeff Grinstead", 
+            "Robert Kraus", 
+            "Steve Matney", 
+            "Robert Qu"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=7564", 
+        "ogcNumber": "04-085", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-02-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "EA-SIG Collaboration White Paper"
+    }, 
+    "ogc-04-086": {
+        "authors": [
+            "Jeff Harrison", 
+            "A.J. Maren", 
+            "Jeff Stohlman", 
+            "Mike Meyer", 
+            "Glenn Pruitt", 
+            "John Clink", 
+            "Hans Polzer", 
+            "Mark Schiffner"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=7563", 
+        "ogcNumber": "04-086", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-02-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "EA-SIG Discovery White Paper"
+    }, 
+    "ogc-04-087": {
+        "authors": [
+            "Matt Murray", 
+            "Jeff Stollman", 
+            "Shue-Jane Thompson", 
+            "Terry Plymell", 
+            "Eli Hertz", 
+            "Chuck Heazel"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=7562", 
+        "ogcNumber": "04-087", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-02-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "EA-SIG Enterprise Service Management White Paper"
+    }, 
+    "ogc-04-088": {
+        "authors": [
+            "Paul Lunceford", 
+            "Steve Matney", 
+            "Tom Huggins", 
+            "Chuck Heazel"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=7561", 
+        "ogcNumber": "04-088", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-02-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "EA-SIG Mediation White Paper"
+    }, 
+    "ogc-04-094": {
+        "authors": [
+            "Peter Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=8339", 
+        "ogcNumber": "04-094", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-05-03", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Web Feature Service (WFS) Implementation Specification"
+    }, 
+    "ogc-04-094r1": {
+        "authors": [
+            "Panagiotis A. Vretanos"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/04-094r1/04-094r1.html", 
+        "ogcNumber": "04-094r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-10-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Web Feature Service Implementation Specification with Corrigendum"
+    }, 
+    "ogc-04-095": {
+        "authors": [
+            "Peter Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=8340", 
+        "ogcNumber": "04-095", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-05-03", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Filter Encoding Implementation Specification"
+    }, 
+    "ogc-04-095c1": {
+        "authors": [
+            "Peter Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51130", 
+        "ogcNumber": "04-095c1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-05-03", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Filter Encoding Implementation Specification Corrigendum 1"
+    }, 
+    "ogc-04-100": {
+        "authors": [
+            "Clemens Portele"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=8071", 
+        "ogcNumber": "04-100", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-04-13", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-2 Application Schema Development"
+    }, 
+    "ogc-04-107": {
+        "authors": [
+            "George Percivall"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=7467", 
+        "ogcNumber": "04-107", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2004-10-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 7 - Earth Imagery"
+    }, 
+    "ogc-05-005": {
+        "authors": [
+            "Jerome Sonnet"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=8618", 
+        "ogcNumber": "05-005", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-05-03", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Web Map Context Implementation Specification"
+    }, 
+    "ogc-05-007": {
+        "authors": [
+            "Peter Schut"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=8723", 
+        "ogcNumber": "05-007", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-01-24", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Processing Service"
+    }, 
+    "ogc-05-007r2": {
+        "authors": [
+            "Peter Schut"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=10634", 
+        "ogcNumber": "05-007r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-06-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Processing Service"
+    }, 
+    "ogc-05-007r4": {
+        "authors": [
+            "Peter Schut", 
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=12184", 
+        "ogcNumber": "05-007r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-09-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Processing Service"
+    }, 
+    "ogc-05-007r7": {
+        "authors": [
+            "Peter Schut"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=24151", 
+        "ogcNumber": "05-007r7", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-10-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Processing Service"
+    }, 
+    "ogc-05-008c1": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=8798", 
+        "ogcNumber": "05-008c1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-05-03", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Web Service Common Implementation Specification"
+    }, 
+    "ogc-05-010": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=8814", 
+        "ogcNumber": "05-010", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-01-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "URNs of definitions in ogc namespace"
+    }, 
+    "ogc-05-011": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=8837", 
+        "ogcNumber": "05-011", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-01-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Recommended XML/GML 3.1.1 encoding of common CRS definitions"
+    }, 
+    "ogc-05-013": {
+        "authors": [
+            "Arliss Whiteside", 
+            "Markus U. M"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=8847", 
+        "ogcNumber": "05-013", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-04-13", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Coordinate Transformation Service"
+    }, 
+    "ogc-05-014": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=8848", 
+        "ogcNumber": "05-014", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-01-31", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Image CRSs for IH4DS"
+    }, 
+    "ogc-05-015": {
+        "authors": [
+            "Barry Schlesinger"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=8826", 
+        "ogcNumber": "05-015", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-01-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Imagery Metadata"
+    }, 
+    "ogc-05-016": {
+        "authors": [
+            "Marwa Mabrouk"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=8836", 
+        "ogcNumber": "05-016", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-05-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Location Service (OpenLS) Implementation Specification: Core Services"
+    }, 
+    "ogc-05-017": {
+        "authors": [
+            "Wenli Yang", 
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=8981", 
+        "ogcNumber": "05-017", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-02-10", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Image Classification Service (WICS)"
+    }, 
+    "ogc-05-019": {
+        "authors": [
+            "Udo Quadt", 
+            "Thomas Kolbe"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=8869", 
+        "ogcNumber": "05-019", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-02-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web 3D Service"
+    }, 
+    "ogc-05-025r3": {
+        "authors": [
+            "Richard Martell"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=12604", 
+        "ogcNumber": "05-025r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-10-24", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Catalogue Services - ebRIM (ISO/TS 15000-3) profile of CSW"
+    }, 
+    "ogc-05-027r1": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=10048", 
+        "ogcNumber": "05-027r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-04-13", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Recommended XML/GML 3.1.1 encoding of image CRS definitions"
+    }, 
+    "ogc-05-029r4": {
+        "authors": [
+            "Ron Lake", 
+            "Carl Reed", 
+            "George Percivall"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=11606", 
+        "ogcNumber": "05-029r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-08-29", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GML Point Profile"
+    }, 
+    "ogc-05-033r9": {
+        "authors": [
+            "Peter Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=11266", 
+        "ogcNumber": "05-033r9", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-07-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GML simple features profile"
+    }, 
+    "ogc-05-035r1": {
+        "authors": [
+            "Jens Fitzke", 
+            "Rob Atkinson"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=13593", 
+        "ogcNumber": "05-035r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-01-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Gazetteer Service Profile of a WFS"
+    }, 
+    "ogc-05-035r2": {
+        "authors": [
+            "Jens Fitzke", 
+            "Rob Atkinson"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=15529", 
+        "ogcNumber": "05-035r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-07-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Gazetteer Service - Application Profile of the Web Feature Service Implementation Specification"
+    }, 
+    "ogc-05-036": {
+        "authors": [
+            "Andreas Matheus"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=10471&version=2", 
+        "ogcNumber": "05-036", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-06-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GeoXACML, a spatial extension to XACML"
+    }, 
+    "ogc-05-042r2": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=13140", 
+        "ogcNumber": "05-042r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-11-21", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Web services architecture description"
+    }, 
+    "ogc-05-047r2": {
+        "authors": [
+            "Ron Lake"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=11418", 
+        "ogcNumber": "05-047r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-03-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GML in JPEG 2000 for Geographic Imagery"
+    }, 
+    "ogc-05-047r3": {
+        "authors": [
+            "Martin Kyle", 
+            "David Burggraf", 
+            "Sean Forde", 
+            "Ron Lake"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=13252", 
+        "ogcNumber": "05-047r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-01-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS GML in JPEG 2000 for Geographic Imagery  Encoding Specification"
+    }, 
+    "ogc-05-050": {
+        "authors": [
+            "Craig Bruce"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=12983", 
+        "ogcNumber": "05-050", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-05-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GML Performance Investigations by CubeWerx"
+    }, 
+    "ogc-05-057r3": {
+        "authors": [
+            "Jolyon Martin"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=13885", 
+        "ogcNumber": "05-057r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-02-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Minimal Application Profile for EO Products"
+    }, 
+    "ogc-05-057r4": {
+        "authors": [
+            "Jolyon Martin"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=14443", 
+        "ogcNumber": "05-057r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-03-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Catalogue Services - Best Practices for for Earth Observation Products"
+    }, 
+    "ogc-05-076": {
+        "authors": [
+            "John Evans"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=12582", 
+        "ogcNumber": "05-076", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-03-31", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Web Coverage Service (WCS) Implementation Specification (Corrigendum)"
+    }, 
+    "ogc-05-077": {
+        "authors": [
+            "Dr. Markus M"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=12636", 
+        "ogcNumber": "05-077", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-04-21", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Symbology Encoding Implementation Specification"
+    }, 
+    "ogc-05-077r4": {
+        "authors": [
+            "Dr. Markus Mueller"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=16700", 
+        "ogcNumber": "05-077r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-01-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Symbology Encoding Implementation Specification"
+    }, 
+    "ogc-05-078": {
+        "authors": [
+            "Dr. Markus M"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=12637", 
+        "ogcNumber": "05-078", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-04-21", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Styled Layer Descriptor Profile of the Web Map Service Implementation Specification"
+    }, 
+    "ogc-05-078r4": {
+        "authors": [
+            "Markus Lupp"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=22364", 
+        "ogcNumber": "05-078r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-08-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Styled Layer Descriptor Profile of the Web Map Service Implementation Specification"
+    }, 
+    "ogc-05-084": {
+        "authors": [
+            "Vincent Delfosse"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=12597", 
+        "ogcNumber": "05-084", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-05-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Catalog 2.0 Accessibility for OWS3"
+    }, 
+    "ogc-05-086": {
+        "authors": [
+            "Mike Botts"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=12606", 
+        "ogcNumber": "05-086", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-11-21", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Sensor Model Language (SensorML)"
+    }, 
+    "ogc-05-087r3": {
+        "authors": [
+            "Simon Cox"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=14034", 
+        "ogcNumber": "05-087r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-04-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Observations and Measurements"
+    }, 
+    "ogc-05-087r4": {
+        "authors": [
+            "Simon Cox"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=17038", 
+        "ogcNumber": "05-087r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-10-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Observations and Measurements"
+    }, 
+    "ogc-05-088r1": {
+        "authors": [
+            "Arthur Na", 
+            "Mark Priest"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=12846", 
+        "ogcNumber": "05-088r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-01-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Sensor Observation Service"
+    }, 
+    "ogc-05-089r1": {
+        "authors": [
+            "Ingo Simonis"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=12971", 
+        "ogcNumber": "05-089r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-12-01", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Sensor Planning Service"
+    }, 
+    "ogc-05-094r1": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=13203", 
+        "ogcNumber": "05-094r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-07-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GML 3.1.1 CRS support profile"
+    }, 
+    "ogc-05-095r1": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=13204", 
+        "ogcNumber": "05-095r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-07-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GML 3.1.1 common CRSs profile"
+    }, 
+    "ogc-05-096r1": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=13205", 
+        "ogcNumber": "05-096r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-07-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GML 3.1.1 grid CRSs profile"
+    }, 
+    "ogc-05-099r2": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=13206", 
+        "ogcNumber": "05-099r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-07-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GML 3.1.1 simple dictionary profile"
+    }, 
+    "ogc-05-101": {
+        "authors": [
+            "David Burggraf"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=13396", 
+        "ogcNumber": "05-101", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-04-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS 3 GML Investigations - Performance Experiment by Galdos Systems"
+    }, 
+    "ogc-05-102r1": {
+        "authors": [
+            "David Burggraf", 
+            "Stan Tillman"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=14337", 
+        "ogcNumber": "05-102r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-05-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS3 GML Topology Investigation"
+    }, 
+    "ogc-05-107": {
+        "authors": [
+            "Thomas Uslander (Ed.)"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=12574", 
+        "ogcNumber": "05-107", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-01-31", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Reference Model for the ORCHESTRA Architecture"
+    }, 
+    "ogc-05-109r1": {
+        "authors": [
+            "Panagiotis (Peter) A. Vretanos", 
+            "Rento Primavera"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=14143", 
+        "ogcNumber": "05-109r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-05-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Catalog 2.0 IPR for ebRIM"
+    }, 
+    "ogc-05-110": {
+        "authors": [
+            "Arliss Whiteside", 
+            "Bill Woodward", 
+            "co-editor"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=13186", 
+        "ogcNumber": "05-110", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-04-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Feature Portrayal Service"
+    }, 
+    "ogc-05-111r2": {
+        "authors": [
+            "Roland M. Wagner"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=13958", 
+        "ogcNumber": "05-111r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-05-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Access Control & Terms of Use (ToU)  \"Click-through\" IPR Management"
+    }, 
+    "ogc-05-112": {
+        "authors": [
+            "Milan Trninic"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=13285", 
+        "ogcNumber": "05-112", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-04-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Symbology Management"
+    }, 
+    "ogc-05-115": {
+        "authors": [
+            "Joe Lewis"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=12899", 
+        "ogcNumber": "05-115", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-03-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Geo Video Web Service"
+    }, 
+    "ogc-05-116": {
+        "authors": [
+            "Stan Tillman", 
+            "Jody Garnett"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=12911", 
+        "ogcNumber": "05-116", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-03-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS Integrated Client (GeoDSS Client)"
+    }, 
+    "ogc-05-117": {
+        "authors": [
+            "Clemens Portele"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=12893", 
+        "ogcNumber": "05-117", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-05-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Schema Maintenance and Tailoring"
+    }, 
+    "ogc-05-118": {
+        "authors": [
+            "Clemens Portele", 
+            "Rafael Renkert"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=12894", 
+        "ogcNumber": "05-118", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-04-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Web Services (OWS) 3 UGAS Tool"
+    }, 
+    "ogc-05-126": {
+        "authors": [
+            "Keith Ryden"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=13227", 
+        "ogcNumber": "05-126", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2005-11-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Implementation Specification for Geographic information - Simple feature access - Part 1: Common architectu"
+    }, 
+    "ogc-05-134": {
+        "authors": [
+            "Keith Ryden"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=13228", 
+        "ogcNumber": "05-134", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "1999-05-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Simple Features - SQL - Binary Geometry"
+    }, 
+    "ogc-05-140": {
+        "authors": [
+            "Yves Coene"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=13916", 
+        "ogcNumber": "05-140", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-03-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-3 Imagery Workflow Experiments: Enhanced Service Infrastructure Technology Architecture and Standards in the OWS-3 Testbe"
+    }, 
+    "ogc-06-002r1": {
+        "authors": [
+            "Joshua Lieberman"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=15198", 
+        "ogcNumber": "06-002r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-08-21", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Geospatial Semantic Web Interoperabiltiy Experiment Report"
+    }, 
+    "ogc-06-004r4": {
+        "authors": [
+            "Graham Vowles"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=17802", 
+        "ogcNumber": "06-004r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-01-29", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 18 - Geospatial Digital Rights Management Reference Model (GeoDRM RM)"
+    }, 
+    "ogc-06-009r6": {
+        "authors": [
+            "Arthur Na", 
+            "Mark Priest"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=26667", 
+        "ogcNumber": "06-009r6", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-02-13", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Sensor Observation Service"
+    }, 
+    "ogc-06-010r6": {
+        "authors": [
+            "Steve Havens"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=19371", 
+        "ogcNumber": "06-010r6", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-07-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Transducer Markup Language *RETIRED*"
+    }, 
+    "ogc-06-021r1": {
+        "authors": [
+            "Mike Botts", 
+            "Alex Robin", 
+            "John Davidson", 
+            "Ingo Simonis"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=14140", 
+        "ogcNumber": "06-021r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-03-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Sensor Web Enablement Architecture Document"
+    }, 
+    "ogc-06-021r2": {
+        "authors": [
+            "Ingo Simonis"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=27775", 
+        "ogcNumber": "06-021r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-07-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Sensor Web Enablement Architecture"
+    }, 
+    "ogc-06-021r4": {
+        "authors": [
+            "Ingo Simonis"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=29405", 
+        "ogcNumber": "06-021r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-08-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Sensor Web Enablement Architecture"
+    }, 
+    "ogc-06-022r1": {
+        "authors": [
+            "James Resler"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=14898", 
+        "ogcNumber": "06-022r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-04-21", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Temporal Standard Recommendations"
+    }, 
+    "ogc-06-023r1": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=16339", 
+        "ogcNumber": "06-023r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-08-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Definition identifier URNs in OGC namespace"
+    }, 
+    "ogc-06-024r4": {
+        "authors": [
+            "CS Smyth"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=25487", 
+        "ogcNumber": "06-024r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-09-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Location Services (OpenLS): Tracking Service Interface Standard"
+    }, 
+    "ogc-06-027r1": {
+        "authors": [
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=14145", 
+        "ogcNumber": "06-027r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-08-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Web Feature Service (WFS) Implementation Specification (Corrigendum)"
+    }, 
+    "ogc-06-028": {
+        "authors": [
+            "Ingo Simonis"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=13921", 
+        "ogcNumber": "06-028", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-04-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Sensor Alert Service"
+    }, 
+    "ogc-06-028r3": {
+        "authors": [
+            "Ingo Simonis"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=15588", 
+        "ogcNumber": "06-028r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-05-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Sensor Alert Service"
+    }, 
+    "ogc-06-035r1": {
+        "authors": [
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=14022", 
+        "ogcNumber": "06-035r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-05-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Coverage Processing Service"
+    }, 
+    "ogc-06-042": {
+        "authors": [
+            "Jeff de La Beaujardiere"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=14416", 
+        "ogcNumber": "06-042", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-03-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Web Map Service (WMS) Implementation Specification"
+    }, 
+    "ogc-06-043r3": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=17909", 
+        "ogcNumber": "06-043r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-05-10", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Change Request: WCS: Add Transaction operation"
+    }, 
+    "ogc-06-045r1": {
+        "authors": [
+            "Eric LaMar"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=14698", 
+        "ogcNumber": "06-045r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-07-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "WMS - Proposed Animation Service Extension"
+    }, 
+    "ogc-06-049r1": {
+        "authors": [
+            "Peter Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=15201", 
+        "ogcNumber": "06-049r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-05-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GML 3.1.1 simple features profile"
+    }, 
+    "ogc-06-050r3": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=15755", 
+        "ogcNumber": "06-050r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-07-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GeoRSS, An Introduction to"
+    }, 
+    "ogc-06-054r1": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=16080", 
+        "ogcNumber": "06-054r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-07-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Image Geopostioning Service"
+    }, 
+    "ogc-06-055r1": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=16081", 
+        "ogcNumber": "06-055r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-07-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS GML 3.2 image geopositioning metadata application schema"
+    }, 
+    "ogc-06-057r1": {
+        "authors": [
+            "Thomas Kolbe", 
+            "Gerhard Groeger", 
+            "Angela Czerwinski"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=16675", 
+        "ogcNumber": "06-057r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-08-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "City Geography Markup Language"
+    }, 
+    "ogc-06-079r1": {
+        "authors": [
+            "Marc Gilles"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=15547", 
+        "ogcNumber": "06-079r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-06-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "EO Application Profile for CSW 2.0"
+    }, 
+    "ogc-06-080": {
+        "authors": [
+            "Jerome Gasperi"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=15546", 
+        "ogcNumber": "06-080", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-07-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GML Application Schema for EO Products"
+    }, 
+    "ogc-06-080r1": {
+        "authors": [
+            "Jerome Gasperi"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=19094", 
+        "ogcNumber": "06-080r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-02-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GML Application Schema for EO Products"
+    }, 
+    "ogc-06-080r2": {
+        "authors": [
+            "Jerome Gasperi"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=22161", 
+        "ogcNumber": "06-080r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-08-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GML Application Schema for EO Products"
+    }, 
+    "ogc-06-080r4": {
+        "authors": [
+            "Jerome Gasperi"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=31065", 
+        "ogcNumber": "06-080r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-02-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GML 3.1.1 Application Schema for EO products"
+    }, 
+    "ogc-06-083r8": {
+        "authors": [
+            "John Evans"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=18153", 
+        "ogcNumber": "06-083r8", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-02-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Web Coverage Service (WCS) Implementation Specification"
+    }, 
+    "ogc-06-093": {
+        "authors": [
+            "Thomas H.G. Lankester"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=16075", 
+        "ogcNumber": "06-093", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-10-24", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Web Map Services - Application Profile for EO Products"
+    }, 
+    "ogc-06-095": {
+        "authors": [
+            "Ingo Simonis", 
+            "Johannes Echterhoff"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=18776", 
+        "ogcNumber": "06-095", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-01-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Notification Service"
+    }, 
+    "ogc-06-098": {
+        "authors": [
+            "Michael Gerlek"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=20257", 
+        "ogcNumber": "06-098", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-08-13", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Change Request: WCS: Proposal for WCS Transactional - WCS-T"
+    }, 
+    "ogc-06-103r3": {
+        "authors": [
+            "John Herring"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=18241", 
+        "ogcNumber": "06-103r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-01-29", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Implementation Specification for Geographic information - Simple feature access - Part 1: Common architecture"
+    }, 
+    "ogc-06-103r4": {
+        "authors": [
+            "John Herring"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=25355", 
+        "ogcNumber": "06-103r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-05-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Implementation Specification for Geographic information - Simple feature access - Part 1: Common architecture"
+    }, 
+    "ogc-06-104r3": {
+        "authors": [
+            "John Herring"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=18242", 
+        "ogcNumber": "06-104r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-01-29", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Implementation Specification for Geographic information - Simple feature access - Part 2: SQL option"
+    }, 
+    "ogc-06-104r4": {
+        "authors": [
+            "John Herring"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=25354", 
+        "ogcNumber": "06-104r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-08-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Implementation Specification for Geographic information - Simple feature access - Part 2: SQL option"
+    }, 
+    "ogc-06-107r1": {
+        "authors": [
+            "Cristian Opincaru"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=20859", 
+        "ogcNumber": "06-107r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-05-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Trusted Geo Services IPR"
+    }, 
+    "ogc-06-111": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=16571", 
+        "ogcNumber": "06-111", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-07-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GML 3.1.1 grid CRSs Profile Corrigendum"
+    }, 
+    "ogc-06-113": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=16572", 
+        "ogcNumber": "06-113", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-07-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GML 3.1.1 common CRSs profile Corrigendum"
+    }, 
+    "ogc-06-121r3": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=20040", 
+        "ogcNumber": "06-121r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-04-03", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Web Service Common Implementation Specification"
+    }, 
+    "ogc-06-121r9": {
+        "authors": [
+            "Arliss Whiteside Jim Greenwood"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=38867", 
+        "ogcNumber": "06-121r9", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-04-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Web Service Common Implementation Specification"
+    }, 
+    "ogc-06-126": {
+        "authors": [
+            "Chuck Morris"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=16860", 
+        "ogcNumber": "06-126", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-10-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Compliance Test Language (CTL) Discussion Paper"
+    }, 
+    "ogc-06-126r2": {
+        "authors": [
+            "Chuck Morris"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=33085", 
+        "ogcNumber": "06-126r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-07-21", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Compliance Test Language (CTL) Best Practice"
+    }, 
+    "ogc-06-129r1": {
+        "authors": [
+            "Patrick Neal", 
+            "John Davidson", 
+            "Bruce Westcott"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=16936", 
+        "ogcNumber": "06-129r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-12-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "FGDC CSDGM Application Profile for CSW 2.0"
+    }, 
+    "ogc-06-131": {
+        "authors": [
+            "Renato Primavera"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=17689", 
+        "ogcNumber": "06-131", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2006-10-24", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "EO Products Extension Package for ebRIM (ISO/TS 15000-3) Profile of CSW 2.0"
+    }, 
+    "ogc-06-131r4": {
+        "authors": [
+            "Renato Primavera"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=28152", 
+        "ogcNumber": "06-131r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-07-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "EO Products Extension Package for ebRIM (ISO/TS 15000-3) Profile of CSW 2.0"
+    }, 
+    "ogc-06-131r6": {
+        "authors": [
+            "Fr\u00e9d\u00e9ric Houbie", 
+            "Lorenzo Bigagli"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=35528", 
+        "ogcNumber": "06-131r6", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-02-10", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Catalogue Services Standard 2.0 Extension Package for ebRIM Application Profile: Earth Observation Products"
+    }, 
+    "ogc-06-135r1": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=17566", 
+        "ogcNumber": "06-135r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-01-29", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Specification best practices"
+    }, 
+    "ogc-06-140": {
+        "authors": [
+            "Dr. Markus M"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=19084", 
+        "ogcNumber": "06-140", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-06-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Feature Styling IPR"
+    }, 
+    "ogc-06-141r2": {
+        "authors": [
+            "Daniele Marchionni"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=22114", 
+        "ogcNumber": "06-141r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-08-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Ordering Services for Earth Observation Products"
+    }, 
+    "ogc-06-141r6": {
+        "authors": [
+            "Daniele Marchionni", 
+            "Stefania Pappagallo"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=43928", 
+        "ogcNumber": "06-141r6", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-01-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Ordering Services Framework for Earth Observation Products  Interface Standard"
+    }, 
+    "ogc-06-142r1": {
+        "authors": [
+            "Carl Reed", 
+            "Martin Thomson"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=21630", 
+        "ogcNumber": "06-142r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-05-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GML PIDF-LO Geometry Shape Application Schema for use in the IETF"
+    }, 
+    "ogc-06-154": {
+        "authors": [
+            "David S. Burggraf", 
+            "Ron Lake", 
+            "Darko Androsevic"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=19580", 
+        "ogcNumber": "06-154", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-08-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS 4 WFS Temporal Investigation"
+    }, 
+    "ogc-06-155": {
+        "authors": [
+            "Tim Wilson", 
+            "Renato Primavera", 
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=20430", 
+        "ogcNumber": "06-155", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-06-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-4 CSW ebRIM Modelling Guidelines IPR"
+    }, 
+    "ogc-06-166": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=18747", 
+        "ogcNumber": "06-166", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-01-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "A URN namespace for the Open Geospatial Consortium (OGC)"
+    }, 
+    "ogc-06-173r2": {
+        "authors": [
+            "John Herring"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=19054", 
+        "ogcNumber": "06-173r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-01-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Geographic information - Rights expression language for geographic information - Part xx: GeoREL"
+    }, 
+    "ogc-06-182r1": {
+        "authors": [
+            "Steven Keens"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=19424", 
+        "ogcNumber": "06-182r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-06-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Discussions, findings, and use of WPS in OWS-4"
+    }, 
+    "ogc-06-184r2": {
+        "authors": [
+            "Christian Elfers", 
+            "Roland M. Wagner"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=21285", 
+        "ogcNumber": "06-184r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-08-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GeoDRM Engineering Viewpoint and supporting Architecture"
+    }, 
+    "ogc-06-187r1": {
+        "authors": [
+            "Steven Keens"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=19778", 
+        "ogcNumber": "06-187r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-05-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-4 Workflow IPR"
+    }, 
+    "ogc-06-188r1": {
+        "authors": [
+            "Simon Cox"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=20794", 
+        "ogcNumber": "06-188r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-05-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GML Encoding of Discrete Coverages (interleaved pattern)"
+    }, 
+    "ogc-06-189": {
+        "authors": [
+            "Chris Holmes"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=19208", 
+        "ogcNumber": "06-189", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-08-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Corrigendum 1 (one) for OpenGIS Implementation Specification GML 2.1.2"
+    }, 
+    "ogc-07-000": {
+        "authors": [
+            "Mike Botts"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=21273", 
+        "ogcNumber": "07-000", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-07-24", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Sensor Model Language (SensorML)"
+    }, 
+    "ogc-07-001r3": {
+        "authors": [
+            "Simon Cox"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=21352", 
+        "ogcNumber": "07-001r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-05-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Requirements for some specific simple solid, plane and line geometry types"
+    }, 
+    "ogc-07-002r3": {
+        "authors": [
+            "Simon Cox"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=22467", 
+        "ogcNumber": "07-002r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-12-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Observations and Measurements - Part 2 - Sampling Features"
+    }, 
+    "ogc-07-004": {
+        "authors": [
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=20431", 
+        "ogcNumber": "07-004", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-05-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GeoDDS Mass Market (formerly GeoRSS) Interoperability Program Report"
+    }, 
+    "ogc-07-006r1": {
+        "authors": [
+            "Nebert", 
+            "Whiteside", 
+            "Vretanos", 
+            "editors"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=20555", 
+        "ogcNumber": "07-006r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-04-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Catalogue Service Implementation Specification [Catalogue Service for the Web]"
+    }, 
+    "ogc-07-007r1": {
+        "authors": [
+            "Paul Watson"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=21821", 
+        "ogcNumber": "07-007r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-06-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS4 - Topology Quality Assessment Interoperability Program Report"
+    }, 
+    "ogc-07-009r3": {
+        "authors": [
+            "Shayne Urbanowski"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=22873", 
+        "ogcNumber": "07-009r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-08-13", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Web Services Architectural Profile for the NSG"
+    }, 
+    "ogc-07-010": {
+        "authors": [
+            "Doug Nebert"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=20561", 
+        "ogcNumber": "07-010", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-06-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Revision Notes for Corrigendum for OpenGIS 07-006: Catalogue Services, Version 2.0.2"
+    }, 
+    "ogc-07-011": {
+        "authors": [
+            "OGC"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=19820", 
+        "ogcNumber": "07-011", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-12-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 6 - Schema for coverage geometry and functions"
+    }, 
+    "ogc-07-012": {
+        "authors": [
+            "Jennifer Marcus", 
+            "Chuck Morris"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=20582", 
+        "ogcNumber": "07-012", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-09-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Compliance Test Engine Interoperability Program Report"
+    }, 
+    "ogc-07-014r3": {
+        "authors": [
+            "Ingo Simonis"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=23180", 
+        "ogcNumber": "07-014r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-08-10", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Sensor Planning Service Implementation Specification"
+    }, 
+    "ogc-07-018": {
+        "authors": [
+            "Philippe M"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=20583", 
+        "ogcNumber": "07-018", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-05-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Sensor Planning Service Application Profile for EO Sensors"
+    }, 
+    "ogc-07-018r1": {
+        "authors": [
+            "Philippe M"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=21465", 
+        "ogcNumber": "07-018r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-08-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Sensor Planning Service Application Profile for EO Sensors"
+    }, 
+    "ogc-07-018r2": {
+        "authors": [
+            "Philippe M"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=25199", 
+        "ogcNumber": "07-018r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-01-21", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Sensor Planning Service Application Profile for EO Sensors"
+    }, 
+    "ogc-07-022r1": {
+        "authors": [
+            "Simon Cox"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=22466", 
+        "ogcNumber": "07-022r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-12-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Observations and Measurements - Part 1 - Observation schema"
+    }, 
+    "ogc-07-023r2": {
+        "authors": [
+            "Paul Cote"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=21622", 
+        "ogcNumber": "07-023r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-05-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Web Services Architecture for CAD GIS and BIM"
+    }, 
+    "ogc-07-024": {
+        "authors": [
+            "Thomas Uslander (Ed.)"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=20300", 
+        "ogcNumber": "07-024", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-07-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Reference Model for the ORCHESTRA Architecture"
+    }, 
+    "ogc-07-026r2": {
+        "authors": [
+            "Andreas Matheus", 
+            "Jan Herrmann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=25218", 
+        "ogcNumber": "07-026r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-02-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Geospatial eXtensible Access Control Markup Language (GeoXACML)"
+    }, 
+    "ogc-07-027r1": {
+        "authors": [
+            "Clemens Portele"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=21702", 
+        "ogcNumber": "07-027r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-05-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Local MSD Implementation Profile (GML 3.2.1)"
+    }, 
+    "ogc-07-028r1": {
+        "authors": [
+            "Clemens Portele"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=21628", 
+        "ogcNumber": "07-028r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-05-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GEOINT Structure Implementation Profile Schema Processing"
+    }, 
+    "ogc-07-032": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=20586", 
+        "ogcNumber": "07-032", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-06-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Frame image geopositioning metadata GML 3.2 application schema"
+    }, 
+    "ogc-07-036": {
+        "authors": [
+            "Clemens Portele"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=20509", 
+        "ogcNumber": "07-036", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-10-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Geography Markup Language (GML) Encoding Standard"
+    }, 
+    "ogc-07-036r1": {
+        "authors": [
+            "Clemens Portele"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=74183&version=2", 
+        "ogcNumber": "07-036r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-04-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Geography Markup Language (GML) Encoding Standard - with corrigendum"
+    }, 
+    "ogc-07-038": {
+        "authors": [
+            "Nicolas Lesage", 
+            "Marie-Lise Vautier"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=20596", 
+        "ogcNumber": "07-038", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-06-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Cataloguing of ISO Metadata (CIM) using the ebRIM profile of CS-W"
+    }, 
+    "ogc-07-039r1": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=21469", 
+        "ogcNumber": "07-039r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-05-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "KML 2.1 Reference - An OGC Best Practice"
+    }, 
+    "ogc-07-041r1": {
+        "authors": [
+            "Ilya Zaslavsky", 
+            "David Valentine", 
+            "Tim Whiteaker"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=21743", 
+        "ogcNumber": "07-041r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-05-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "CUAHSI WaterML"
+    }, 
+    "ogc-07-045": {
+        "authors": [
+            "Uwe Voges", 
+            "Kristian Senkler"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=21460", 
+        "ogcNumber": "07-045", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-08-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Catalogue Services Specification 2.0.2 - ISO Metadata Application Profile"
+    }, 
+    "ogc-07-045r1": {
+        "authors": [
+            "Uwe Voges", 
+            "Kristian Senkler"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=77949", 
+        "ogcNumber": "07-045r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-03-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS\u00ae Catalogue Services Specification 2.0.2 - ISO Metadata Application Profile: Corrigendum"
+    }, 
+    "ogc-07-055r1": {
+        "authors": [
+            "Arliss Whiteside", 
+            "Markus U. M"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=24314", 
+        "ogcNumber": "07-055r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-10-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Coordinate Transformation Service"
+    }, 
+    "ogc-07-056r1": {
+        "authors": [
+            "John Herring", 
+            "OAB", 
+            "Architecture WG"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=21976", 
+        "ogcNumber": "07-056r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-07-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "The Specification Model -- Structuring an OGC specification to encourage implementation"
+    }, 
+    "ogc-07-057r2": {
+        "authors": [
+            "Keith Pomakis"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=23206", 
+        "ogcNumber": "07-057r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-10-10", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Tiled WMS Discussion Paper"
+    }, 
+    "ogc-07-057r7": {
+        "authors": [
+            "Joan Mas\u00f3", 
+            "Keith Pomakis", 
+            "N\u00faria Juli\u00e0"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=35326", 
+        "ogcNumber": "07-057r7", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-04-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Web Map Tile Service Implementation Standard"
+    }, 
+    "ogc-07-061": {
+        "authors": [
+            "Clemens Portele"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=26765", 
+        "ogcNumber": "07-061", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-02-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Revision Notes for OpenGIS\u00ae Implementation Specification: Geographic information - Geography Markup Language Version 3.2.1"
+    }, 
+    "ogc-07-062": {
+        "authors": [
+            "Gerhard Gr"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=22120", 
+        "ogcNumber": "07-062", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-08-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "City Geography Markup Language"
+    }, 
+    "ogc-07-063": {
+        "authors": [
+            "Thomas H.G. Lankester"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=21742", 
+        "ogcNumber": "07-063", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-08-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Map Services - Application Profile for EO Products"
+    }, 
+    "ogc-07-063r1": {
+        "authors": [
+            "Thomas H.G. Lankester"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=30912", 
+        "ogcNumber": "07-063r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-11-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Map Services - Application Profile for EO Products"
+    }, 
+    "ogc-07-066r5": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=27298", 
+        "ogcNumber": "07-066r5", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-04-29", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Corrigendum 2 for the OGC Standard Web Coverage Service 1.1"
+    }, 
+    "ogc-07-067r2": {
+        "authors": [
+            "Arliss Whiteside", 
+            "John Evans"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=22560", 
+        "ogcNumber": "07-067r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-08-29", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Web Coverage Service (WCS) Implementation Specification Corrigendum 1"
+    }, 
+    "ogc-07-067r5": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=27297", 
+        "ogcNumber": "07-067r5", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-04-29", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Coverage Service (WCS) Implementation Standard"
+    }, 
+    "ogc-07-068r4": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=28506", 
+        "ogcNumber": "07-068r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-01-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Coverage Service (WCS) - Transaction operation extension"
+    }, 
+    "ogc-07-074": {
+        "authors": [
+            "Marwa Mabrouk"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=22122", 
+        "ogcNumber": "07-074", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-09-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Location Service (OpenLS) Implementation Specification: Core Services"
+    }, 
+    "ogc-07-092r1": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=24045", 
+        "ogcNumber": "07-092r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-11-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Definition identifier URNs in OGC namespace"
+    }, 
+    "ogc-07-092r3": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=30575", 
+        "ogcNumber": "07-092r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-01-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Definition identifier URNs in OGC namespace"
+    }, 
+    "ogc-07-095r2": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=23979", 
+        "ogcNumber": "07-095r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-11-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Web Services Summaries"
+    }, 
+    "ogc-07-097": {
+        "authors": [
+            "Thomas Uslander (Ed.)"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=23286", 
+        "ogcNumber": "07-097", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-10-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Reference Model for the ORCHESTRA Architecture"
+    }, 
+    "ogc-07-098r1": {
+        "authors": [
+            "Andreas Matheus"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=25219", 
+        "ogcNumber": "07-098r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-02-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GeoXACML Implementation Specification - Extension A (GML2) Encoding"
+    }, 
+    "ogc-07-099r1": {
+        "authors": [
+            "Andreas Matheus"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=25220", 
+        "ogcNumber": "07-099r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-02-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GeoXACML Implementation Specification - Extension B (GML3) Encoding"
+    }, 
+    "ogc-07-107r3": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=27357", 
+        "ogcNumber": "07-107r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-05-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "A URN namespace for the Open Geospatial Consortium (OGC)"
+    }, 
+    "ogc-07-110r2": {
+        "authors": [
+            "Richard Martell"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=27092", 
+        "ogcNumber": "07-110r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-03-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "CSW-ebRIM Registry Service - Part 1: ebRIM profile of CSW"
+    }, 
+    "ogc-07-110r4": {
+        "authors": [
+            "Richard Martell"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=31137", 
+        "ogcNumber": "07-110r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-02-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "CSW-ebRIM Registry Service - Part 1: ebRIM profile of CSW"
+    }, 
+    "ogc-07-113r1": {
+        "authors": [
+            "Google", 
+            "Galdos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=23689", 
+        "ogcNumber": "07-113r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-11-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "KML 2.2 Reference - An OGC Best Practice"
+    }, 
+    "ogc-07-118r8": {
+        "authors": [
+            "P Denis"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=40677", 
+        "ogcNumber": "07-118r8", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-09-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "User Management for Earth Observation Services"
+    }, 
+    "ogc-07-118r9": {
+        "authors": [
+            "P. Denis", 
+            "P. Jacques"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=54929", 
+        "ogcNumber": "07-118r9", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-04-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC User Management Interfaces for Earth Observation Services"
+    }, 
+    "ogc-07-122r2": {
+        "authors": [
+            "Mike Botts", 
+            "Simon Cox"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=24757", 
+        "ogcNumber": "07-122r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2007-11-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS SensorML Encoding Standard v 1.0 Schema Corregendum 1"
+    }, 
+    "ogc-07-124r2": {
+        "authors": [
+            "Chris Holmes"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=28086", 
+        "ogcNumber": "07-124r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-09-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-5 KML Engineering Report"
+    }, 
+    "ogc-07-134r2": {
+        "authors": [
+            "Richard Martell"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=27811", 
+        "ogcNumber": "07-134r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-04-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC KML 2.2 -Abstract Test Suite"
+    }, 
+    "ogc-07-138r1": {
+        "authors": [
+            "Michael Werling"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=30065", 
+        "ogcNumber": "07-138r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-09-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-5 GeoProcessing Workflow Architecture Engineering Report"
+    }, 
+    "ogc-07-144r2": {
+        "authors": [
+            "Richard Martell"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=27093", 
+        "ogcNumber": "07-144r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-03-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "CSW-ebRIM Registry Service - Part 2: Basic extension package"
+    }, 
+    "ogc-07-144r4": {
+        "authors": [
+            "Richard Martell"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=31138", 
+        "ogcNumber": "07-144r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-02-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "CSW-ebRIM Registry Service - Part 2: Basic extension package"
+    }, 
+    "ogc-07-147r2": {
+        "authors": [
+            "Tim Wilson"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=27810", 
+        "ogcNumber": "07-147r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-04-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC KML"
+    }, 
+    "ogc-07-152": {
+        "authors": [
+            "Corentin Guillo"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=25184", 
+        "ogcNumber": "07-152", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-01-21", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "FedEO Pilot Engineering Report"
+    }, 
+    "ogc-07-158": {
+        "authors": [
+            "R"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=25280", 
+        "ogcNumber": "07-158", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-01-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Wrapping OGC HTTP-GET/POST Services with SOAP"
+    }, 
+    "ogc-07-160r1": {
+        "authors": [
+            "Pete Brennen"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=30064", 
+        "ogcNumber": "07-160r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-09-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-5 Conflation Engineering Report"
+    }, 
+    "ogc-07-163": {
+        "authors": [
+            "David Rosinger", 
+            "Stan Tillman"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=27330", 
+        "ogcNumber": "07-163", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-05-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-5 Data View Architecture Engineering Report"
+    }, 
+    "ogc-07-165r1": {
+        "authors": [
+            "Carl Reed", 
+            "Mike Botts", 
+            "George Percivall", 
+            "John Davidson"
+        ], 
+        "href": "http://docs.opengeospatial.org/wp/07-165r1/", 
+        "ogcNumber": "07-165r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-04-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Sensor Web Enablement: Overview And High Level Architecture"
+    }, 
+    "ogc-07-166r2": {
+        "authors": [
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=27052", 
+        "ogcNumber": "07-166r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-08-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC OWS-5 Engineering Report on WCPS"
+    }, 
+    "ogc-07-169": {
+        "authors": [
+            "Steven Keens"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=27047", 
+        "ogcNumber": "07-169", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-09-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-5 WCS JPIP Coverage Subsetting Engineering Report"
+    }, 
+    "ogc-07-172r1": {
+        "authors": [
+            "Kristin Stock"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=26730", 
+        "ogcNumber": "07-172r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-05-13", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Feature Type Catalogue Extension Package for ebRIM (ISO/TS 15000-3) Profile of CSW 2.0"
+    }, 
+    "ogc-08-000": {
+        "authors": [
+            "Raj SIngh"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=26608", 
+        "ogcNumber": "08-000", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-04-29", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Canadian Geospatial Data Infrastructure Summary Report"
+    }, 
+    "ogc-08-001": {
+        "authors": [
+            "Raj Singh"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=26609", 
+        "ogcNumber": "08-001", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-04-29", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Loosely Coupled Synchronization of Geographic Databases in the Canadian Geospatial Data Infrastructure Pilot"
+    }, 
+    "ogc-08-002": {
+        "authors": [
+            "Peter Rushforth"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=26610", 
+        "ogcNumber": "08-002", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-04-29", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Canadian Geospatial Data Infrastructure WFS and GML Best Practices"
+    }, 
+    "ogc-08-007r1": {
+        "authors": [
+            "Gerhard Gr\u00f6ger", 
+            "Thomas H. Kolbe", 
+            "Angela Czerwinski", 
+            "Claus Nagel"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=28802", 
+        "ogcNumber": "08-007r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-08-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS\u00ae  City Geography Markup Language (CityGML) Encoding Standard"
+    }, 
+    "ogc-08-008r1": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=27711", 
+        "ogcNumber": "08-008r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-04-29", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS\u00ae Abstract Specification Proposed Topic 19: General Reference Systems"
+    }, 
+    "ogc-08-009r1": {
+        "authors": [
+            "Bastian Schaeffer"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=26521", 
+        "ogcNumber": "08-009r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-02-21", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS 5 SOAP/WSDL Common Engineering Report"
+    }, 
+    "ogc-08-015r2": {
+        "authors": [
+            "Roger Lott"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=39049", 
+        "ogcNumber": "08-015r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-04-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 2 - Spatial referencing by coordinates"
+    }, 
+    "ogc-08-022r1": {
+        "authors": [
+            "Simon Cox"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=27697", 
+        "ogcNumber": "08-022r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-05-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Change Request - O&M Part 1 - Move extensions to new namespace"
+    }, 
+    "ogc-08-028r7": {
+        "authors": [
+            "Gil Fuchs"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=28493", 
+        "ogcNumber": "08-028r7", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-09-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Location Services (OpenLS): Part 6 - Navigation Service"
+    }, 
+    "ogc-08-050": {
+        "authors": [
+            "Tom Kralidis"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=27286", 
+        "ogcNumber": "08-050", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-05-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Web Map Context Documents Corrigendum 1"
+    }, 
+    "ogc-08-053r2": {
+        "authors": [
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=32888", 
+        "ogcNumber": "08-053r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-03-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "WCS Processing Extension (WCPS) Abstract Test Suite"
+    }, 
+    "ogc-08-054r1": {
+        "authors": [
+            "Max Martinez"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=29406", 
+        "ogcNumber": "08-054r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-08-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-5 Considerations for the WCTS Extension of WPS"
+    }, 
+    "ogc-08-054r4": {
+        "authors": [
+            "Lucio Colaiacomo", 
+            "Joan Mas\u00f3", 
+            "Emmanuel Devys"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/08-085r4/08-085r4.html", 
+        "ogcNumber": "08-054r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-09-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae GML in JPEG 2000 (GMLJP2) Encoding Standard Part 1: Core "
+    }, 
+    "ogc-08-058r1": {
+        "authors": [
+            "Stefan Falke"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=30061", 
+        "ogcNumber": "08-058r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-09-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-5 Earth Observation Web Processing Services (WPS) Engineering Report"
+    }, 
+    "ogc-08-059r3": {
+        "authors": [
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=32416", 
+        "ogcNumber": "08-059r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-03-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Web Coverage Service (WCS) - Processing Extension (WCPS)"
+    }, 
+    "ogc-08-059r4": {
+        "authors": [
+            "Peter Baumann", 
+            "Jinsongdi Yu"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=54506", 
+        "ogcNumber": "08-059r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-02-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Web Coverage Service WCS Interface Standard - Processing Extension"
+    }, 
+    "ogc-08-062r7": {
+        "authors": [
+            "George Percivall"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=47245", 
+        "ogcNumber": "08-062r7", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-12-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Reference Model"
+    }, 
+    "ogc-08-068r2": {
+        "authors": [
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=32319", 
+        "ogcNumber": "08-068r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-03-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Web Coverage Processing Service (WCPS) Language Interface Standard"
+    }, 
+    "ogc-08-069r2": {
+        "authors": [
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=32314", 
+        "ogcNumber": "08-069r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-03-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Coverage Processing Service (WCPS) Abstract Test Suite"
+    }, 
+    "ogc-08-071": {
+        "authors": [
+            "Mike Botts"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=29466", 
+        "ogcNumber": "08-071", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-09-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS 5 Engineering Report:  Supporting Georeferenceable Imagery"
+    }, 
+    "ogc-08-073r2": {
+        "authors": [
+            "Jessica Cook", 
+            "Raj Singh"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=29426", 
+        "ogcNumber": "08-073r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-09-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Summary of the OGC Web Services, Phase 5 (OWS-5) Interoperability Testbed"
+    }, 
+    "ogc-08-076": {
+        "authors": [
+            "R\u00fcdiger Gartmann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=28162", 
+        "ogcNumber": "08-076", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-09-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-5 GeoRM License Broker Discussion Paper"
+    }, 
+    "ogc-08-077": {
+        "authors": [
+            "Clemens Portele"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=28170", 
+        "ogcNumber": "08-077", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-07-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae OWS-5 Engineering Report: Local MSD Implementation Profile (GML 3.2.1)"
+    }, 
+    "ogc-08-078r1": {
+        "authors": [
+            "Clemens Portele"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=29029", 
+        "ogcNumber": "08-078r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-07-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae OWS-5 ER: GSIP Schema Processing"
+    }, 
+    "ogc-08-079": {
+        "authors": [
+            "John Herring"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=28176", 
+        "ogcNumber": "08-079", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-09-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS5: OGC Web feature service, core and extensions"
+    }, 
+    "ogc-08-084r1": {
+        "authors": [
+            "Jen Marcus"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=29505", 
+        "ogcNumber": "08-084r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-08-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-5 CITE Summary Engineering Report"
+    }, 
+    "ogc-08-085r5": {
+        "authors": [
+            "Lucio Colaiacomo", 
+            "Joan Mas\u00f3", 
+            "Emmanuel Devys"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/08-085r5/08-085r5.html", 
+        "ogcNumber": "08-085r5", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-04-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC GML in JPEG 2000 (GMLJP2) Encoding StandardPart 1: Core"
+    }, 
+    "ogc-08-085r8": {
+        "authors": [
+            "Lucio Colaiacomo", 
+            "Joan Mas\u00f3", 
+            "Emmanuel Devys", 
+            "Eric Hirschorn"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/18-085r8/18-085r8.html", 
+        "ogcNumber": "08-085r8", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-08-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae GML in JPEG 2000 (GMLJP2) Encoding Standard"
+    }, 
+    "ogc-08-091r6": {
+        "authors": [
+            "Peter Schut"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=32766", 
+        "ogcNumber": "08-091r6", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-09-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Corrigendum for OpenGIS Implementation Standard Web Processing Service (WPS) 1.0.0"
+    }, 
+    "ogc-08-094r1": {
+        "authors": [
+            "Alexandre Robin"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=41157", 
+        "ogcNumber": "08-094r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-01-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae SWE Common Data Model Encoding Standard"
+    }, 
+    "ogc-08-103r2": {
+        "authors": [
+            "Richard Martell"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=31139", 
+        "ogcNumber": "08-103r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-02-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "CSW-ebRIM Registry Service - Part 3: Abstract Test Suite"
+    }, 
+    "ogc-08-122r2": {
+        "authors": [
+            "Matthew Williams", 
+            "Dan Cornford", 
+            "Lucy Bastin & Edzer Pebesma"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=33234", 
+        "ogcNumber": "08-122r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-04-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Uncertainty Markup Language (UnCertML)"
+    }, 
+    "ogc-08-124r1": {
+        "authors": [
+            "Luis Bermudez"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=29535", 
+        "ogcNumber": "08-124r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-01-03", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Ocean Science Interoperability Experiment Phase 1 Report"
+    }, 
+    "ogc-08-125r1": {
+        "authors": [
+            "Tim Wilson", 
+            "David Burggraf"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=30203", 
+        "ogcNumber": "08-125r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-02-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae KML Standard Development Best Practices"
+    }, 
+    "ogc-08-126": {
+        "authors": [
+            "Cliff Kottman", 
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=29536", 
+        "ogcNumber": "08-126", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-01-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 5 - Features"
+    }, 
+    "ogc-08-127": {
+        "authors": [
+            "Simon Cox"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=29542", 
+        "ogcNumber": "08-127", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-08-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GML 3.2 implementation of XML schemas in 07-000"
+    }, 
+    "ogc-08-128": {
+        "authors": [
+            "Simon Cox"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=29543", 
+        "ogcNumber": "08-128", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-03-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GML 3.2 implementation of XML schemas in 07-022r1"
+    }, 
+    "ogc-08-129": {
+        "authors": [
+            "Simon Cox"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=29544", 
+        "ogcNumber": "08-129", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-03-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GML 3.2 implementation of XML schemas in 07-002r3"
+    }, 
+    "ogc-08-131r3": {
+        "authors": [
+            "Policy SWG"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=34762&version=2", 
+        "ogcNumber": "08-131r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-10-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "The Specification Model - Standard for Modular specifications"
+    }, 
+    "ogc-08-132": {
+        "authors": [
+            "Thomas Everding", 
+            "Johannes Echterhoff"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=29566", 
+        "ogcNumber": "08-132", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-11-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Event Pattern Markup Language (EML)"
+    }, 
+    "ogc-08-133": {
+        "authors": [
+            "Johannes Echterhoff", 
+            "Thomas Everding"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=29576", 
+        "ogcNumber": "08-133", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2008-10-10", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS\u00ae Sensor Event Service Interface Specification"
+    }, 
+    "ogc-08-139r3": {
+        "authors": [
+            "George Demmy", 
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=40537", 
+        "ogcNumber": "08-139r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-01-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "PDF Geo-registration Encoding Best Practice Version 2.2"
+    }, 
+    "ogc-08-167r1": {
+        "authors": [
+            "Patrick Mau\u00e9"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=34916", 
+        "ogcNumber": "08-167r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-07-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Semantic annotations in OGC standards"
+    }, 
+    "ogc-08-167r2": {
+        "authors": [
+            "Fr\u00e9d\u00e9ric Houbie", 
+            "Philippe Duchesne", 
+            "Patrick Mau\u00e9"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=47857", 
+        "ogcNumber": "08-167r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-10-10", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Semantic annotations in OGC standards"
+    }, 
+    "ogc-08-176r1": {
+        "authors": [
+            "Andreas Matheus"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=34273", 
+        "ogcNumber": "08-176r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-07-29", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 Secure Sensor Web Engineering Report"
+    }, 
+    "ogc-09-000": {
+        "authors": [
+            "Ingo Simonis", 
+            "Johannes Echterhoff"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=38478", 
+        "ogcNumber": "09-000", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-03-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Sensor Planning Service Implementation Standard"
+    }, 
+    "ogc-09-001": {
+        "authors": [
+            "Johannes Echterhoff"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=38476", 
+        "ogcNumber": "09-001", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-03-21", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS\u00ae SWE Service Model Implementation Standard"
+    }, 
+    "ogc-09-006": {
+        "authors": [
+            "Keith Pomakis"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=33269", 
+        "ogcNumber": "09-006", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-08-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 DSS Engineering Report - SOAP/XML and REST in WMTS"
+    }, 
+    "ogc-09-007": {
+        "authors": [
+            "Scott Fairgrieve"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=33355", 
+        "ogcNumber": "09-007", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-10-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 Common CBRN Sensor Interface (CCSI)-Sensor Web Enablement (SWE) Engineering Report"
+    }, 
+    "ogc-09-010": {
+        "authors": [
+            "Kristin Stock"
+        ], 
+        "href": " http://portal.opengeospatial.org/files/?artifact_id=32620", 
+        "ogcNumber": "09-010", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-07-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Catalogue Services - OWL Application Profile of CSW"
+    }, 
+    "ogc-09-012": {
+        "authors": [
+            "Craig Bruce"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=33519", 
+        "ogcNumber": "09-012", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-08-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 Symbology-Encoding Harmonization ER"
+    }, 
+    "ogc-09-015": {
+        "authors": [
+            "Craig Bruce"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=33516", 
+        "ogcNumber": "09-015", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-09-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 Styled Layer Descriptor (SLD) Changes ER"
+    }, 
+    "ogc-09-016": {
+        "authors": [
+            "Craig Bruce"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=33515", 
+        "ogcNumber": "09-016", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-09-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 Symbology Encoding (SE) Changes ER"
+    }, 
+    "ogc-09-018": {
+        "authors": [
+            "Ben Domenico", 
+            "Stefano Nativi"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=32195", 
+        "ogcNumber": "09-018", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-04-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Coverage Service (WCS) 1.1 extension for CF-netCDF 3.0 encoding"
+    }, 
+    "ogc-09-025r1": {
+        "authors": [
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=39967", 
+        "ogcNumber": "09-025r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-11-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Web Feature Service 2.0 Interface Standard (also ISO 19142)"
+    }, 
+    "ogc-09-025r2": {
+        "authors": [
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/09-025r2/09-025r2.html", 
+        "ogcNumber": "09-025r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-07-10", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Web Feature Service 2.0 Interface Standard - With Corrigendum"
+    }, 
+    "ogc-09-026r1": {
+        "authors": [
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=39968", 
+        "ogcNumber": "09-026r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-11-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Filter Encoding 2.0 Encoding Standard"
+    }, 
+    "ogc-09-026r2": {
+        "authors": [
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/09-026r2/09-026r2.html", 
+        "ogcNumber": "09-026r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-08-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Filter Encoding 2.0 Encoding Standard - With Corrigendum "
+    }, 
+    "ogc-09-031r1": {
+        "authors": [
+            "Thomas Everding"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=34118", 
+        "ogcNumber": "09-031r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-07-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 SWE Information Model Engineering Report"
+    }, 
+    "ogc-09-032": {
+        "authors": [
+            "Thomas Everding", 
+            "Johannes Echterhoff"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=33347", 
+        "ogcNumber": "09-032", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-07-29", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 SWE Event Architecture Engineering Report"
+    }, 
+    "ogc-09-033": {
+        "authors": [
+            "Simon Jirka", 
+            "Arne Br\u00f6ring"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=33284", 
+        "ogcNumber": "09-033", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-07-29", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 SensorML Profile for Discovery Engineering Report"
+    }, 
+    "ogc-09-034": {
+        "authors": [
+            "Genong (Eugene) Yu", 
+            "Liping Di"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=33925", 
+        "ogcNumber": "09-034", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-07-29", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 Georeferencable Imagery Engineering Report"
+    }, 
+    "ogc-09-035": {
+        "authors": [
+            "R\u00fcdiger Gartmann", 
+            "Lewis Leinenweber"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=35461", 
+        "ogcNumber": "09-035", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-10-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 Security Engineering Report"
+    }, 
+    "ogc-09-036r2": {
+        "authors": [
+            "Jan Herrmann", 
+            "Andreas Matheus"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=34976", 
+        "ogcNumber": "09-036r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-07-24", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 GeoXACML Engineering Report"
+    }, 
+    "ogc-09-037r1": {
+        "authors": [
+            "Clemens Portele"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=34098", 
+        "ogcNumber": "09-037r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-07-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 UTDS-CityGML Implementation Profile"
+    }, 
+    "ogc-09-038r1": {
+        "authors": [
+            "Clemens Portele"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=34099", 
+        "ogcNumber": "09-038r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-08-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 GML Profile Validation Tool ER"
+    }, 
+    "ogc-09-041r3": {
+        "authors": [
+            "Bastian Baranski"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=34977", 
+        "ogcNumber": "09-041r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-07-24", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 WPS Grid Processing Profile Engineering Report"
+    }, 
+    "ogc-09-042": {
+        "authors": [
+            "Steffen Neubauer", 
+            "Alexander Zipf"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=32904", 
+        "ogcNumber": "09-042", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-10-13", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "3D-Symbology Encoding Discussion Draft"
+    }, 
+    "ogc-09-046r3": {
+        "authors": [
+            "Simon Cox"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51857", 
+        "ogcNumber": "09-046r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-06-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Naming Authority \u2013 Policies and Procedures "
+    }, 
+    "ogc-09-050r1": {
+        "authors": [
+            "Hans Schoebach"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=34032", 
+        "ogcNumber": "09-050r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-07-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC OWS-6-AIM Engineering Report"
+    }, 
+    "ogc-09-053r5": {
+        "authors": [
+            "Bastian Sch\u00e4ffer"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=34968", 
+        "ogcNumber": "09-053r5", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-10-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 Geoprocessing Workflow Architecture Engineering Report"
+    }, 
+    "ogc-09-063": {
+        "authors": [
+            "Lewis Leinenweber"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=34127", 
+        "ogcNumber": "09-063", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-09-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 GeoProcessing Workflow Thread Summary ER"
+    }, 
+    "ogc-09-064r2": {
+        "authors": [
+            "Ingo Simonis"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=34147", 
+        "ogcNumber": "09-064r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-09-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 Sensor Web Enablement (SWE) Engineering Report"
+    }, 
+    "ogc-09-067r2": {
+        "authors": [
+            "Akiko Sato", 
+            "Nobuhiro Ishimaru", 
+            "Guo Tao", 
+            "Masaaki Tanizaki"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=35334", 
+        "ogcNumber": "09-067r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-10-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 Outdoor and Indoor 3D Routing Services Engineering Report"
+    }, 
+    "ogc-09-072": {
+        "authors": [
+            "James Ressler"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=34146", 
+        "ogcNumber": "09-072", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-08-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 CITE TEAM Engine Engineering Report"
+    }, 
+    "ogc-09-073": {
+        "authors": [
+            "James Ressler"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=34145", 
+        "ogcNumber": "09-073", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-08-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 SWE PulseNet\u2122 Engineering Report"
+    }, 
+    "ogc-09-075r1": {
+        "authors": [
+            "Arne Schilling"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=33949", 
+        "ogcNumber": "09-075r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-08-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-6 3D Flythrough (W3DS) Engineering Report"
+    }, 
+    "ogc-09-076r3": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=35042", 
+        "ogcNumber": "09-076r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-09-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Uses and summary of Topic 2: Spatial referencing by coordinates"
+    }, 
+    "ogc-09-082": {
+        "authors": [
+            "Hsu-Chun James Yu", 
+            "Zhong-Hung Lee", 
+            "Cai-Fang Ye", 
+            "Lan-Kun Chung", 
+            "Yao-Min Fang"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=34126", 
+        "ogcNumber": "09-082", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-07-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Sensor Web Enablement Application for Debris Flow Monitoring System in Taiwan"
+    }, 
+    "ogc-09-083r3": {
+        "authors": [
+            "Adrian Custer"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=39397", 
+        "ogcNumber": "09-083r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-04-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GeoAPI 3.0 Implementation Standard"
+    }, 
+    "ogc-09-083r4": {
+        "authors": [
+            "Adrian Custer"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=71648", 
+        "ogcNumber": "09-083r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-04-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GeoAPI 3.0 Implementation Standard with corrigendum"
+    }, 
+    "ogc-09-084r1": {
+        "authors": [
+            "Jo Walsh", 
+            "Pedro Gon\u00e7alves", 
+            "Andrew Turner"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=35983", 
+        "ogcNumber": "09-084r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-10-13", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenSearch Geospatial Extensions Draft Implementation Standard"
+    }, 
+    "ogc-09-085r2": {
+        "authors": [
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=35653", 
+        "ogcNumber": "09-085r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-10-13", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Grid coverage Coordinate Reference Systems (CRSs)"
+    }, 
+    "ogc-09-102": {
+        "authors": [
+            "Cyril Minoux"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=34833", 
+        "ogcNumber": "09-102", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-09-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "DGIWG WMS 1.3 Profile and systems requirements for interoperability for use within a military environment"
+    }, 
+    "ogc-09-102r3": {
+        "authors": [
+            "Stefan Strobel", 
+            "Dimitri Sarafinof", 
+            "David Wesloh", 
+            "Paul Lacey"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=66915", 
+        "ogcNumber": "09-102r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-01-29", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "DGIWG - Web Map Service 1.3 Profile - Revision"
+    }, 
+    "ogc-09-104r1": {
+        "authors": [
+            "Arne Schilling", 
+            "Thomas H. Kolbe"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=36390", 
+        "ogcNumber": "09-104r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-01-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Draft for Candidate OpenGIS\u00ae Web 3D Service Interface Standard"
+    }, 
+    "ogc-09-110r3": {
+        "authors": [
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=41437", 
+        "ogcNumber": "09-110r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-10-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae WCS 2.0 Interface Standard - Core"
+    }, 
+    "ogc-09-110r4": {
+        "authors": [
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=48428", 
+        "ogcNumber": "09-110r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-07-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae WCS 2.0 Interface Standard- Core:  Corrigendum "
+    }, 
+    "ogc-09-112": {
+        "authors": [
+            "Simon Jirka", 
+            "Arne Br\u00f6ring"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=35471", 
+        "ogcNumber": "09-112", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-10-13", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Sensor Observable Registry Discussion Paper"
+    }, 
+    "ogc-09-112r1": {
+        "authors": [
+            "Simon Jirka", 
+            "Arne Br\u00f6ring", 
+            "Daniel N\u00fcst"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=40571", 
+        "ogcNumber": "09-112r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-10-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Sensor Observable Registry (SOR) Discussion Paper"
+    }, 
+    "ogc-09-122": {
+        "authors": [
+            "Ben Domenico"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=35505", 
+        "ogcNumber": "09-122", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-10-13", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "CF-netCDF Encoding Specification"
+    }, 
+    "ogc-09-123": {
+        "authors": [
+            "Roland M. Wagner"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=35516", 
+        "ogcNumber": "09-123", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-10-13", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GeoRM Role Model"
+    }, 
+    "ogc-09-124r2": {
+        "authors": [
+            "Peter Taylor"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=39090", 
+        "ogcNumber": "09-124r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-06-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Harmonising Standards for Water Observation Data - Discussion Paper"
+    }, 
+    "ogc-09-127r2": {
+        "authors": [
+            "Tom O\u2019Reilly"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=47604", 
+        "ogcNumber": "09-127r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-01-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae PUCK Protocol Standard "
+    }, 
+    "ogc-09-129": {
+        "authors": [
+            "Nadine Alameh"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=35634", 
+        "ogcNumber": "09-129", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-02-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "AIP-2 Use Cases GEOSS Architecture Implementation Pilot, Phase 2 Engineering Report"
+    }, 
+    "ogc-09-132r1": {
+        "authors": [
+            "Thomas Usl\u00e4nder (Ed.)"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=35888", 
+        "ogcNumber": "09-132r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2009-10-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Specification of the Sensor Service Architecture (SensorSA)"
+    }, 
+    "ogc-09-138": {
+        "authors": [
+            "George Percivall"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=36177", 
+        "ogcNumber": "09-138", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-03-21", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Fusion Standards Study Engineering Report"
+    }, 
+    "ogc-09-140r2": {
+        "authors": [
+            "Paul Daisey"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=36336", 
+        "ogcNumber": "09-140r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-07-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae NSG Plugweek Engineering Report"
+    }, 
+    "ogc-09-142r1": {
+        "authors": [
+            "Chun-fu Lin", 
+            "Zhong-Hung Lee", 
+            "Jen-Chu Liu", 
+            "Kuo-Yu Chuang"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=36261", 
+        "ogcNumber": "09-142r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-02-01", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae: Open GeoSMS Specification"
+    }, 
+    "ogc-09-144r2": {
+        "authors": [
+            "Clemens Portele"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=59324", 
+        "ogcNumber": "09-144r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-02-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Technical Committee Policies and Procedures: MIME Media Types for GML"
+    }, 
+    "ogc-09-146r1": {
+        "authors": [
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=41438", 
+        "ogcNumber": "09-146r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-10-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae GML Application Schema - Coverages"
+    }, 
+    "ogc-09-146r2": {
+        "authors": [
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=48553", 
+        "ogcNumber": "09-146r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-05-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Coverage Implementation Schema"
+    }, 
+    "ogc-09-146r6": {
+        "authors": [
+            "Peter Baumann", 
+            "Eric Hirschorn", 
+            "Joan Mas\u00f3"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/09-146r6/09-146r6.html", 
+        "ogcNumber": "09-146r6", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-09-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Coverage Implementation Schema"
+    }, 
+    "ogc-09-147r1": {
+        "authors": [
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=41439", 
+        "ogcNumber": "09-147r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-10-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Web Coverage Service 2.0 Interface Standard - KVP Protocol Binding Extension"
+    }, 
+    "ogc-09-147r3": {
+        "authors": [
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=50140", 
+        "ogcNumber": "09-147r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-03-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Web Coverage Service 2.0 Interface Standard - KVP Protocol Binding Extension - Corrigendum  "
+    }, 
+    "ogc-09-148r1": {
+        "authors": [
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=41440", 
+        "ogcNumber": "09-148r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-10-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Web Coverage Service 2.0 Interface Standard - XML/POST Protocol Binding Extension"
+    }, 
+    "ogc-09-149r1": {
+        "authors": [
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=41441", 
+        "ogcNumber": "09-149r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-10-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Web Coverage Service 2.0 Interface Standard - XML/SOAP Protocol Binding Extension"
+    }, 
+    "ogc-09-153r1": {
+        "authors": [
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46442", 
+        "ogcNumber": "09-153r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-01-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Web Coverage Service 2.0 Primer:  Core and Extensions Overview"
+    }, 
+    "ogc-09-156r2": {
+        "authors": [
+            "Luis Bermudez"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=37373", 
+        "ogcNumber": "09-156r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-01-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Ocean Science Interoperability Experiment Phase II Report "
+    }, 
+    "ogc-09-163r2": {
+        "authors": [
+            "Fre&#769;de&#769;ric Houbie", 
+            "Fabian Skive&#769;e", 
+            "Simon Jirka"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=37944", 
+        "ogcNumber": "09-163r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-04-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "sensorML Extension Package for ebRIM Application Profile"
+    }, 
+    "ogc-09-166r2": {
+        "authors": [
+            "Benjamin Hagedorn"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=37257", 
+        "ogcNumber": "09-166r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-02-01", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web View Service Discussion Paper"
+    }, 
+    "ogc-09-182r1": {
+        "authors": [
+            "Josh Lieberman"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=36889", 
+        "ogcNumber": "09-182r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-02-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "End to End Discovery and Access Engineering Report GEO Architecture Implementation Pilot, Phase 2"
+    }, 
+    "ogc-10-001": {
+        "authors": [
+            "Stuart E. Middleton"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=37139", 
+        "ogcNumber": "10-001", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-03-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "SANY Fusion and Modelling Architecture"
+    }, 
+    "ogc-10-002": {
+        "authors": [
+            "Raj Singh"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=37839", 
+        "ogcNumber": "10-002", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-04-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Climate Challenge Integration Plugfest 2009 Engineering Report"
+    }, 
+    "ogc-10-003r1": {
+        "authors": [
+            "Louis Hecht", 
+            "Jr.", 
+            "Raj Singh"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=37223", 
+        "ogcNumber": "10-003r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-06-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Summary of the Architecture, Engineering, Construction, Owner Operator Phase 1 (AECOO-1) Joint Testbed"
+    }, 
+    "ogc-10-004r3": {
+        "authors": [
+            "Simon Cox"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=41579", 
+        "ogcNumber": "10-004r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-11-10", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 20: Observations and Measurements"
+    }, 
+    "ogc-10-020": {
+        "authors": [
+            "Paul Cooper"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=37761", 
+        "ogcNumber": "10-020", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-04-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 2.1: Spatial Referencing by Coordinates - Extension for Parametric Values"
+    }, 
+    "ogc-10-025r1": {
+        "authors": [
+            "Simon Cox"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=41510", 
+        "ogcNumber": "10-025r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-03-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Observations and Measurements - XML Implementation"
+    }, 
+    "ogc-10-028r1": {
+        "authors": [
+            "Andrea Biancalana", 
+            "Pier Giorgio Marchetti", 
+            "Paul Smits"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=39475", 
+        "ogcNumber": "10-028r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-06-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GIGAS Methodology for comparative analysis of information and data management systems"
+    }, 
+    "ogc-10-030": {
+        "authors": [
+            "Paul Scarponcini"
+        ], 
+        "href": "https://www.iso.org/standard/32566.html", 
+        "ogcNumber": "10-030", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-03-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 19: Geographic information - Linear referencing"
+    }, 
+    "ogc-10-032r8": {
+        "authors": [
+            "Pedro Gon\u00e7alves"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=56866", 
+        "ogcNumber": "10-032r8", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-04-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae OpenSearch Geo and Time Extensions"
+    }, 
+    "ogc-10-035r2": {
+        "authors": [
+            "David Rosinger", 
+            "Stan Tillman"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=40441", 
+        "ogcNumber": "10-035r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-09-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-7 Information Sharing Engineering Report"
+    }, 
+    "ogc-10-036r2": {
+        "authors": [
+            "Stan Tillman"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=40313", 
+        "ogcNumber": "10-036r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-08-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-7 Motion Video Change Detection"
+    }, 
+    "ogc-10-059r2": {
+        "authors": [
+            "Christian Kiehle", 
+            "Theodor Foerster"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=40310", 
+        "ogcNumber": "10-059r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-08-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-7 Web Processing Service Profiling Engineering Report"
+    }, 
+    "ogc-10-060r1": {
+        "authors": [
+            "Johannes Echterhoff"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=39509", 
+        "ogcNumber": "10-060r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-08-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-7 Event Architecture Engineering Report"
+    }, 
+    "ogc-10-061r1": {
+        "authors": [
+            "Johannes Echterhoff", 
+            "Ingo Simonis"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=39513", 
+        "ogcNumber": "10-061r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-06-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-7 Dynamic Sensor Notification Engineering Report"
+    }, 
+    "ogc-10-069r2": {
+        "authors": [
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=39476", 
+        "ogcNumber": "10-069r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-08-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-7 Engineering Report  - Geosynchronization service"
+    }, 
+    "ogc-10-070r2": {
+        "authors": [
+            "Peter Schut"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=40095", 
+        "ogcNumber": "10-070r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-11-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS\u00ae Georeferenced Table Joining Service Implementation Standard"
+    }, 
+    "ogc-10-073r1": {
+        "authors": [
+            "Scott Fairgrieve"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=39728", 
+        "ogcNumber": "10-073r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-06-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-7 CCSI-SWE Best Practices Engineering Report"
+    }, 
+    "ogc-10-074": {
+        "authors": [
+            "Theodor Foerster", 
+            "Bastian Sch\u00e4ffer"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=40311", 
+        "ogcNumber": "10-074", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-08-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-7 Feature and Statistical Analysis Engineering Report"
+    }, 
+    "ogc-10-079r3": {
+        "authors": [
+            "Thomas Everding"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=40133", 
+        "ogcNumber": "10-079r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-09-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-7 Aviation Architecture Engineering Report"
+    }, 
+    "ogc-10-086r1": {
+        "authors": [
+            "Andrew Turner"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=40334", 
+        "ogcNumber": "10-086r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-08-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-7 - Authoritative Data Source Directory Engineering Report"
+    }, 
+    "ogc-10-087": {
+        "authors": [
+            "Wenli Yang", 
+            "Liping Di"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=40139", 
+        "ogcNumber": "10-087", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-08-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-7 Motion Imagery Discovery and Retrieval  Engineering Report"
+    }, 
+    "ogc-10-088r3": {
+        "authors": [
+            "Clemens Portele"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=50438", 
+        "ogcNumber": "10-088r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-04-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae OWS-7 Schema Automation Engineering Report"
+    }, 
+    "ogc-10-090r3": {
+        "authors": [
+            "Ben Domenico"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=43732", 
+        "ogcNumber": "10-090r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-04-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Network Common Data Form (NetCDF)  Core Encoding Standard version 1.0"
+    }, 
+    "ogc-10-091r3": {
+        "authors": [
+            "Ben Domenico"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=43733", 
+        "ogcNumber": "10-091r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-04-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "CF-netCDF Core and Extensions Primer"
+    }, 
+    "ogc-10-092r3": {
+        "authors": [
+            "Ben Domenico"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=43734", 
+        "ogcNumber": "10-092r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-04-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "NetCDF Binary Encoding Extension Standard: NetCDF Classic and 64-bit Offset Format"
+    }, 
+    "ogc-10-094": {
+        "authors": [
+            "David Arctur"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=40840", 
+        "ogcNumber": "10-094", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-10-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-7: Summary of the  OGC Web Services, Phase 7 (OWS-7) Interoperability Testbed"
+    }, 
+    "ogc-10-099r2": {
+        "authors": [
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=39852", 
+        "ogcNumber": "10-099r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-10-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Revision Notes for OpenGIS\u00ae Implementation Specification: Geography Markup Language (GML) simple features profile v2.0"
+    }, 
+    "ogc-10-100r2": {
+        "authors": [
+            "Linda van den Brink", 
+            "Clemens Portele", 
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=39853", 
+        "ogcNumber": "10-100r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-10-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Geography Markup Language (GML) simple features profile"
+    }, 
+    "ogc-10-100r3": {
+        "authors": [
+            "Linda van den Brink", 
+            "Clemens Portele", 
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=42729", 
+        "ogcNumber": "10-100r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-05-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Geography Markup Language (GML) simple features profile (with Corrigendum)"
+    }, 
+    "ogc-10-124r1": {
+        "authors": [
+            "Simon Cox"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=39467", 
+        "ogcNumber": "10-124r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-07-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Identifiers - the case for http URIs"
+    }, 
+    "ogc-10-126r3": {
+        "authors": [
+            "Peter Taylor"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=48531", 
+        "ogcNumber": "10-126r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-08-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae WaterML 2.0: Part 1- Timeseries"
+    }, 
+    "ogc-10-126r4": {
+        "authors": [
+            "Peter Taylor"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=57222", 
+        "ogcNumber": "10-126r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-02-24", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae WaterML 2.0: Part 1- Timeseries"
+    }, 
+    "ogc-10-127r1": {
+        "authors": [
+            "Roger Brackin"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=40134", 
+        "ogcNumber": "10-127r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-08-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-7 Engineering Report - Aviation Portrayal"
+    }, 
+    "ogc-10-129r1": {
+        "authors": [
+            "Clemens Portele"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46568", 
+        "ogcNumber": "10-129r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-02-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Geography Markup Language (GML) - Extended schemas and encoding rules"
+    }, 
+    "ogc-10-130": {
+        "authors": [
+            "Debbie Wilson"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=40114", 
+        "ogcNumber": "10-130", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-08-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-7 Aviation - FUSE Deployment Engineering Report"
+    }, 
+    "ogc-10-131r1": {
+        "authors": [
+            "Debbie Wilson"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=40502", 
+        "ogcNumber": "10-131r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-08-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-7 Aviation - AIXM Assessment Report"
+    }, 
+    "ogc-10-132": {
+        "authors": [
+            "Bruno Simmenauer"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=40149", 
+        "ogcNumber": "10-132", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-08-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-7 Aviation - WXXM Assessment Engineering Report"
+    }, 
+    "ogc-10-134": {
+        "authors": [
+            "Arne Broering", 
+            "Stefan Below"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=39664", 
+        "ogcNumber": "10-134", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-06-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Sensor Interface Descriptors"
+    }, 
+    "ogc-10-135": {
+        "authors": [
+            "Alexandre Robin", 
+            "Philippe M\u00e9rigot"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=40185", 
+        "ogcNumber": "10-135", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-03-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Sensor Planning Service Interface Standard 2.0 Earth Observation Satellite Tasking ExtensionOGC\u00ae Sensor Planning Service"
+    }, 
+    "ogc-10-140r1": {
+        "authors": [
+            "Peter Baumann", 
+            "Stephan Meissl", 
+            "Jinsongdi Yu"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=42722", 
+        "ogcNumber": "10-140r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-02-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Web Coverage Service 2.0 Interface Standard - Earth Observation Application Profile"
+    }, 
+    "ogc-10-140r2": {
+        "authors": [
+            "Peter Baumann", 
+            "Stephan Meissl", 
+            "Jinsongdi Yu"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/10-140r2/10-140r2.html", 
+        "ogcNumber": "10-140r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-10-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Web Coverage Service 2.0 Interface Standard - Earth Observation Application Profile"
+    }, 
+    "ogc-10-155": {
+        "authors": [
+            "Andreas Matheus"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=40144", 
+        "ogcNumber": "10-155", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-08-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-7 - Towards secure interconnection of OGC Web Services with SWIM"
+    }, 
+    "ogc-10-157r3": {
+        "authors": [
+            "Jerome Gasperi", 
+            "Fr\u00e9d\u00e9ric Houbie", 
+            "Andrew Woolf", 
+            "Steven Smolders"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=47040", 
+        "ogcNumber": "10-157r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-06-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Earth Observation Metadata profile of Observations & Measurements"
+    }, 
+    "ogc-10-157r4": {
+        "authors": [
+            "Jerome Gasperi", 
+            "Fr\u00e9d\u00e9ric Houbie", 
+            "Andrew Woolf", 
+            "Steven Smolders"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/10-157r4/10-157r4.html", 
+        "ogcNumber": "10-157r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-06-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Earth Observation Metadata profile of Observations & Measurements"
+    }, 
+    "ogc-10-171": {
+        "authors": [
+            "Simon Jirka", 
+            "Daniel N\u00fcst"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=40609", 
+        "ogcNumber": "10-171", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-10-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Sensor Instance Registry Discussion Paper "
+    }, 
+    "ogc-10-184": {
+        "authors": [
+            "George Percivall"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=41573", 
+        "ogcNumber": "10-184", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-12-13", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Fusion Standards Study, Phase 2 Engineering Report"
+    }, 
+    "ogc-10-189r2": {
+        "authors": [
+            "Fr\u00e9d\u00e9ric Houbie; Fabian Skivee"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=47409", 
+        "ogcNumber": "10-189r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-06-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Cataloguing Earth Observation Products for ebXML Registry Information Model 3.0 based Catalogues"
+    }, 
+    "ogc-10-191r1": {
+        "authors": [
+            "Claus Nagel", 
+            "Thomas Becker", 
+            "Robert Kaden", 
+            "Ki-Joune Li", 
+            "Jiyeong Lee", 
+            "Thomas H. Kolbe"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=41727", 
+        "ogcNumber": "10-191r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-12-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Requirements and Space-Event Modeling for Indoor Navigation"
+    }, 
+    "ogc-10-192": {
+        "authors": [
+            "Jeff Harrison"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=41734", 
+        "ogcNumber": "10-192", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-01-03", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Authentication IE Enginerring Report "
+    }, 
+    "ogc-10-194r3": {
+        "authors": [
+            "Boyan Brodaric", 
+            "Nate Booth"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=43545", 
+        "ogcNumber": "10-194r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-03-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Groundwater Interoperability Experiment FINAL REPORT"
+    }, 
+    "ogc-10-195": {
+        "authors": [
+            "OGC Aviation Domain Working Group"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=41667", 
+        "ogcNumber": "10-195", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-03-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Requirements for Aviation Metadata"
+    }, 
+    "ogc-10-196r1": {
+        "authors": [
+            "OGC Aviation Domain Working Group"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=41668", 
+        "ogcNumber": "10-196r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-03-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Guidance on the Aviation Metadata Profile"
+    }, 
+    "ogc-11-013r6": {
+        "authors": [
+            "Luis Bermudez", 
+            "David Arctur"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=44834", 
+        "ogcNumber": "11-013r6", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-07-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Engineering Report: Water Information Services Concept Development Study"
+    }, 
+    "ogc-11-014r3": {
+        "authors": [
+            "Stanislav Vanecek", 
+            "Roger Moore"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=59022", 
+        "ogcNumber": "11-014r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-05-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Open Modelling Interface Interface Standard"
+    }, 
+    "ogc-11-017": {
+        "authors": [
+            "Andreas Matheus", 
+            "Jan Herrmann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=42734", 
+        "ogcNumber": "11-017", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-05-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Geospatial eXtensible Access Control Markup Language (GeoXACML) Version 1 Corrigendum"
+    }, 
+    "ogc-11-018": {
+        "authors": [
+            "R\u00fcdiger Gartmann", 
+            "Bastian Sch\u00e4ffer"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=42735", 
+        "ogcNumber": "11-018", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-03-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "License-Based Access Control"
+    }, 
+    "ogc-11-019r2": {
+        "authors": [
+            "Chris Higgins"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=47852", 
+        "ogcNumber": "11-019r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-04-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Engineering Report for the OWS Shibboleth Interoperability Experiment"
+    }, 
+    "ogc-11-030r1": {
+        "authors": [
+            "Kuan-Mei Chen", 
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=44146", 
+        "ogcNumber": "11-030r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-01-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae: Open GeoSMS Standard - Core"
+    }, 
+    "ogc-11-035r1": {
+        "authors": [
+            "Fr\u00e9d\u00e9ric Houbie", 
+            "Steven Smolders"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=53276", 
+        "ogcNumber": "11-035r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-03-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "EO Product Collection, Service and Sensor Discovery using the CS-W ebRIM Catalogue"
+    }, 
+    "ogc-11-038R2": {
+        "authors": [
+            "Ben Domenico"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=50294", 
+        "ogcNumber": "11-038R2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-10-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Network Common Data Form (NetCDF) NetCDF Enhanced Data Model Extension Standard"
+    }, 
+    "ogc-11-039r2": {
+        "authors": [
+            "Rob Atkinson", 
+            "Irina Dornblut"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=47831", 
+        "ogcNumber": "11-039r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-04-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "HY_Features: a Common Hydrologic Feature Model Discussion Paper"
+    }, 
+    "ogc-11-039r3": {
+        "authors": [
+            "Irina Dornblut", 
+            "Rob Atkinson"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=55157", 
+        "ogcNumber": "11-039r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-02-24", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC HY_Features: a Common Hydrologic Feature Model"
+    }, 
+    "ogc-11-044": {
+        "authors": [
+            "Linda van den Brink", 
+            "Clemens Portele", 
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=43999", 
+        "ogcNumber": "11-044", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-05-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Geography Markup Language (GML) simple features profile Technical Note"
+    }, 
+    "ogc-11-052r4": {
+        "authors": [
+            "Matthew Perry", 
+            "John Herring"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=47664", 
+        "ogcNumber": "11-052r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-06-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC GeoSPARQL - A Geographic Query Language for RDF Data"
+    }, 
+    "ogc-11-053r1": {
+        "authors": [
+            "Peter Baumann", 
+            "Jinsongdi Yu"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=54209", 
+        "ogcNumber": "11-053r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-03-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Web Coverage Service Interface Standard - CRS Extension"
+    }, 
+    "ogc-11-055": {
+        "authors": [
+            "Steve Miller"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=44939", 
+        "ogcNumber": "11-055", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-11-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC SAA Pilot Study Engineering Report"
+    }, 
+    "ogc-11-058r1": {
+        "authors": [
+            "Ingo Simonis", 
+            "Chrsitian Malewski"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=44438", 
+        "ogcNumber": "11-058r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-07-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "*FL Starfish Fungus Language for Sensor Description "
+    }, 
+    "ogc-11-061r1": {
+        "authors": [
+            "David Burggraf"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=45380", 
+        "ogcNumber": "11-061r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-02-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-8 AIXM Metadata Guidelines Engineering Report"
+    }, 
+    "ogc-11-062r2": {
+        "authors": [
+            "David Burggraf", 
+            "Ron Lake"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46548", 
+        "ogcNumber": "11-062r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-11-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-8 CCI Portrayal Registries Engineering Report"
+    }, 
+    "ogc-11-063r6": {
+        "authors": [
+            "Gobe Hobona", 
+            "Roger Brackin"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46342", 
+        "ogcNumber": "11-063r6", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-11-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-8 Cross Community Interoperability (CCI) Semantic Mediation Engineering Report"
+    }, 
+    "ogc-11-064r3": {
+        "authors": [
+            "Clemens Portele", 
+            "Reinhard Erstling"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46324", 
+        "ogcNumber": "11-064r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-11-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-8 CCI Schema Automation Engineering Report"
+    }, 
+    "ogc-11-072r2": {
+        "authors": [
+            "Wenny Rahayu", 
+            "Torab Torabi", 
+            "Andrew Taylor-Harris", 
+            "Florian Puersch"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46322", 
+        "ogcNumber": "11-072r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-01-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-8 Aviation - WXXM Engineering Report"
+    }, 
+    "ogc-11-073r2": {
+        "authors": [
+            "Debbie Wilson", 
+            "Ian Painter"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46666", 
+        "ogcNumber": "11-073r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-02-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-8 Aviation: Guidance for Retrieving AIXM 5.1 data via an OGC WFS 2.0"
+    }, 
+    "ogc-11-085r1": {
+        "authors": [
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46679", 
+        "ogcNumber": "11-085r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-11-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-8 Bulk Geodata Transfer Using GML Engineering Report"
+    }, 
+    "ogc-11-086r1": {
+        "authors": [
+            "Jan Herrmann", 
+            "Andreas Matheus"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46019", 
+        "ogcNumber": "11-086r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-01-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-8 Aviation Thread - Authoritative AIXM Data Source Engineering Report"
+    }, 
+    "ogc-11-088r1": {
+        "authors": [
+            "Johannes Echterhoff", 
+            "Thomas Everding"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=45850", 
+        "ogcNumber": "11-088r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-11-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Event Service - Review and Current State"
+    }, 
+    "ogc-11-089r1": {
+        "authors": [
+            "Daniel Tagesson"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46228", 
+        "ogcNumber": "11-089r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-11-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-8 Engineering Report - Guidelines for International Civil Aviation Organization (ICAO) portrayal using SLD/SE"
+    }, 
+    "ogc-11-091": {
+        "authors": [
+            "Richard Martell"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46094", 
+        "ogcNumber": "11-091", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-02-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-8 Review of the WXXS exchange schemas"
+    }, 
+    "ogc-11-092r2": {
+        "authors": [
+            "Johannes Echterhoff", 
+            "Matthes Rieke"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46243", 
+        "ogcNumber": "11-092r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-04-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-8 Report on Digital NOTAM Event Specification"
+    }, 
+    "ogc-11-093r2": {
+        "authors": [
+            "Johannes Echterhoff"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46242", 
+        "ogcNumber": "11-093r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-12-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-8 Aviation Architecture Engineering Report"
+    }, 
+    "ogc-11-094": {
+        "authors": [
+            "Bastian Baranski"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=45403", 
+        "ogcNumber": "11-094", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-11-24", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "WS-Agreement Application Profile for OGC Web Services"
+    }, 
+    "ogc-11-095r1": {
+        "authors": [
+            "Stephan Meissl", 
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=47826", 
+        "ogcNumber": "11-095r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-12-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-8 WCS 2.0 Earth Observation Application Profile Compliance Tests Engineering Report"
+    }, 
+    "ogc-11-096": {
+        "authors": [
+            "Stephan Meissl", 
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=45404", 
+        "ogcNumber": "11-096", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-11-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-8 WCS 2.0 Earth Observation Application Profile Engineering Report"
+    }, 
+    "ogc-11-097": {
+        "authors": [
+            "J\u00e9r\u00f4me JANSOU", 
+            "Thibault DACLA"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46394", 
+        "ogcNumber": "11-097", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-12-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-8 AIXM 5.1 Compression Benchmarking"
+    }, 
+    "ogc-11-106r1": {
+        "authors": [
+            "Rob Atkinson", 
+            "James Groffen"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46227", 
+        "ogcNumber": "11-106r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-12-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-8 Digital NOTAM Refactor"
+    }, 
+    "ogc-11-108": {
+        "authors": [
+            "Ingo Simonis"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46170", 
+        "ogcNumber": "11-108", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-05-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-8 Analysis of OGC Standards for Supporting Mobile Object Processing Implementation (Engineering Report)"
+    }, 
+    "ogc-11-111": {
+        "authors": [
+            "Daniele Marchionni"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=45124", 
+        "ogcNumber": "11-111", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-01-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Ordering Services for Earth Observation Products  Adoption Voting Comments and Answers"
+    }, 
+    "ogc-11-111r1": {
+        "authors": [
+            "ISO"
+        ], 
+        "href": "http://www.iso.org/iso/home/store/catalogue_ics/catalogue_detail_ics.htm?csnumber=53798", 
+        "ogcNumber": "11-111r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-09-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 11 - Metadata"
+    }, 
+    "ogc-11-113r1": {
+        "authors": [
+            "Ingo Simonis"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46171", 
+        "ogcNumber": "11-113r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-11-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-8 Information Model for Moving Target Indicators and Moving Object Bookmarks (Engineering Report)"
+    }, 
+    "ogc-11-114": {
+        "authors": [
+            "David Danko", 
+            "Lance Shipman", 
+            "Paul Ramsey"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=45754", 
+        "ogcNumber": "11-114", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-11-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-8 Bulk Geodata Transfer with File Geodatabase"
+    }, 
+    "ogc-11-116": {
+        "authors": [
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46793", 
+        "ogcNumber": "11-116", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-12-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-8 Geoprocessing for Earth Observations Engineering Report"
+    }, 
+    "ogc-11-122r1": {
+        "authors": [
+            "Jeff Harrison", 
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46964", 
+        "ogcNumber": "11-122r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-11-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Gazetteer Service - Application Profile of the Web Feature Service Candidate Implementation Standard"
+    }, 
+    "ogc-11-134": {
+        "authors": [
+            "Rob Cass", 
+            "Mark Simms"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46372", 
+        "ogcNumber": "11-134", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-05-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-8 Tracking: Moving Target Indicator Process, Workflows and Implementation Results ER"
+    }, 
+    "ogc-11-135r2": {
+        "authors": [
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=53819", 
+        "ogcNumber": "11-135r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-06-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Name Type Specification for Coordinate Reference Systems"
+    }, 
+    "ogc-11-139r2": {
+        "authors": [
+            "David Arctur"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=47018", 
+        "ogcNumber": "11-139r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-12-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Summary of the OGC Web Services, Phase 8 (OWS-8) Interoperability Testbed"
+    }, 
+    "ogc-11-157": {
+        "authors": [
+            "Jim Greenwood"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46435", 
+        "ogcNumber": "11-157", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-10-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Corrigendum 1 for OGC Web Services Common Standard v2.0.0 - Multilingual"
+    }, 
+    "ogc-11-158": {
+        "authors": [
+            "Jim Greenwood"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46436", 
+        "ogcNumber": "11-158", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-10-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Corrigendum 2 for OGC Web Services Common Specification v 1.1.0 - Exception Report"
+    }, 
+    "ogc-11-163": {
+        "authors": [
+            "Lorenzo Bigagli", 
+            "StefanoNativi"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46702", 
+        "ogcNumber": "11-163", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-01-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "NetCDF Uncertainty Conventions "
+    }, 
+    "ogc-11-165r2": {
+        "authors": [
+            "Ben Domenico", 
+            "Stefano Nativi"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51908", 
+        "ogcNumber": "11-165r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-01-03", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "CF-netCDF3 Data Model Extension standard"
+    }, 
+    "ogc-11-169": {
+        "authors": [
+            "Simon Jirka", 
+            "Christoph Stasch", 
+            "Arne Br\u00f6ring"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46693", 
+        "ogcNumber": "11-169", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-12-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Lightweight SOS Profile for Stationary In-Situ Sensors Discussion Paper"
+    }, 
+    "ogc-11-169r1": {
+        "authors": [
+            "Simon Jirka", 
+            "Christoph Stasch", 
+            "Arne Br\u00f6ring"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=52803", 
+        "ogcNumber": "11-169r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-02-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Best Practice for Sensor Web Enablement Lightweight SOS Profile for Stationary In-Situ Sensors"
+    }, 
+    "ogc-12-000": {
+        "authors": [
+            "Mike Botts", 
+            "Alexandre Robin"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=55939", 
+        "ogcNumber": "12-000", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-02-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae SensorML: Model and XML Encoding Standard"
+    }, 
+    "ogc-12-006": {
+        "authors": [
+            "Arne Br\u00f6ring", 
+            "Christoph Stasch", 
+            "Johannes Echterhoff"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=47599", 
+        "ogcNumber": "12-006", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-04-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Sensor Observation Service Interface Standard"
+    }, 
+    "ogc-12-007r2": {
+        "authors": [
+            "David Burggraf"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/12-007r2/12-007r2.html", 
+        "ogcNumber": "12-007r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-08-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC KML 2.3"
+    }, 
+    "ogc-12-018r1": {
+        "authors": [
+            "Peter Fitch"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=47989", 
+        "ogcNumber": "12-018r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-05-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Surface Water Interoperability Experiment FINAL REPORT"
+    }, 
+    "ogc-12-018r2": {
+        "authors": [
+            "Peter Fitch"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=50166", 
+        "ogcNumber": "12-018r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-08-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Surface Water Interoperability Experiment FINAL REPORT "
+    }, 
+    "ogc-12-019": {
+        "authors": [
+            "Gerhard Gr\u00f6ger", 
+            "Thomas H. Kolbe", 
+            "Claus Nagel", 
+            "Karl-Heinz H\u00e4fele"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=47842", 
+        "ogcNumber": "12-019", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-04-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC City Geography Markup Language (CityGML) Encoding Standard"
+    }, 
+    "ogc-12-027r2": {
+        "authors": [
+            "Timo Thomas"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51815", 
+        "ogcNumber": "12-027r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-06-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Web Feature Service (WFS) Temporality Extension "
+    }, 
+    "ogc-12-027r3": {
+        "authors": [
+            "Timo Thomas"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=58922", 
+        "ogcNumber": "12-027r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-07-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Web Feature Service (WFS) Temporality Extension"
+    }, 
+    "ogc-12-028": {
+        "authors": [
+            "OGC Aviation Domain Working Group"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=47859", 
+        "ogcNumber": "12-028", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-05-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Guidance and Profile of GML for use with Aviation Data"
+    }, 
+    "ogc-12-028r1": {
+        "authors": [
+            "OGC Aviation Domain Working Group"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=62061", 
+        "ogcNumber": "12-028r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-03-24", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Use of Geography Markup Language (GML) for Aviation Data"
+    }, 
+    "ogc-12-029": {
+        "authors": [
+            "Bastian Sch\u00e4ffer"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=47860", 
+        "ogcNumber": "12-029", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-04-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Web Processing Service Best Practices Discussion Paper"
+    }, 
+    "ogc-12-031r2": {
+        "authors": [
+            "Doug Palmer"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=49025", 
+        "ogcNumber": "12-031r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-07-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "WaterML 2.0 - Timeseries - NetCDF Discussion Paper"
+    }, 
+    "ogc-12-032r2": {
+        "authors": [
+            "Rahul Thakkar", 
+            "Michael Maraist"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=50486", 
+        "ogcNumber": "12-032r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-12-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "WAMI Services: Dissemination Services for Wide Area Motion Imagery - Best Practice"
+    }, 
+    "ogc-12-039": {
+        "authors": [
+            "Peter Baumann", 
+            "Jinsongdi Yu"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=54504", 
+        "ogcNumber": "12-039", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-02-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Web Coverage Service Interface Standard -  Scaling Extension"
+    }, 
+    "ogc-12-040": {
+        "authors": [
+            "Peter Baumann", 
+            "Jinsongdi Yu"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=54503", 
+        "ogcNumber": "12-040", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-02-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Web Coverage Service Interface Standard - Range Subsetting Extension"
+    }, 
+    "ogc-12-049": {
+        "authors": [
+            "Peter Baumann", 
+            "Jinsongdi Yu"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=54502", 
+        "ogcNumber": "12-049", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-02-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Web Coverage Service Interface Standard -  Interpolation Extension"
+    }, 
+    "ogc-12-052": {
+        "authors": [
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=48650", 
+        "ogcNumber": "12-052", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-07-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC WCS 2.0.1 Corrigendum Release Notes"
+    }, 
+    "ogc-12-063r5": {
+        "authors": [
+            "Roger Lott"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/12-063r5/12-063r5.html", 
+        "ogcNumber": "12-063r5", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-05-01", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Geographic information \u2014 Well known text representation of coordinate reference systems"
+    }, 
+    "ogc-12-066": {
+        "authors": [
+            "Linda van den Brink", 
+            "Jantien Stoter", 
+            "Sisi Zlatanova"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=49000&version=2", 
+        "ogcNumber": "12-066", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-07-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Modeling an application domain extension of CityGML in UML"
+    }, 
+    "ogc-12-075": {
+        "authors": [
+            "Arne Schilling", 
+            "Benjamin Hagedorn", 
+            "Volker Coors"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=49068", 
+        "ogcNumber": "12-075", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-08-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC 3D Portrayal Interoperability Experiment  FINAL REPORT "
+    }, 
+    "ogc-12-077r1": {
+        "authors": [
+            "Rahul Thakkar"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=50485", 
+        "ogcNumber": "12-077r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-12-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "A Primer for Dissemination Services for Wide Area Motion Imagery "
+    }, 
+    "ogc-12-080r2": {
+        "authors": [
+            "Roger Brackin", 
+            "Pedro Gon\u00e7alves"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=55182", 
+        "ogcNumber": "12-080r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-01-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC OWS Context Conceptual Model"
+    }, 
+    "ogc-12-081": {
+        "authors": [
+            "Simon Cox"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51856", 
+        "ogcNumber": "12-081", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-06-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Name type specification \u2013 ontology resources"
+    }, 
+    "ogc-12-084r2": {
+        "authors": [
+            "Roger Brackin", 
+            "Pedro Gon\u00e7alves"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=55183", 
+        "ogcNumber": "12-084r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-01-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC OWS Context Atom Encoding Standard"
+    }, 
+    "ogc-12-093": {
+        "authors": [
+            "Clemens Portele"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51784", 
+        "ogcNumber": "12-093", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-02-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-9: UML-to-GML-Application-Schema (UGAS) Conversion Engineering Report"
+    }, 
+    "ogc-12-094": {
+        "authors": [
+            "Debbie Wilson", 
+            "Clemens Portele"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51807", 
+        "ogcNumber": "12-094", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-02-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-9 Aviation: AIRM Derivation"
+    }, 
+    "ogc-12-095": {
+        "authors": [
+            "James Gallagher", 
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=52783", 
+        "ogcNumber": "12-095", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-06-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae OWS-9 Innovation - Coverages: Coverage Access (OPeNDAP) Study"
+    }, 
+    "ogc-12-096": {
+        "authors": [
+            "Mike Botts"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=52162", 
+        "ogcNumber": "12-096", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-02-01", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-9: Engineering Report: Use of SWE Common and SensorML for GPS Messaging "
+    }, 
+    "ogc-12-097": {
+        "authors": [
+            "Jeff Harrison"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51998", 
+        "ogcNumber": "12-097", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-03-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-9 Engineering Report - SSI - Bulk Data Transfer (GML Streaming)"
+    }, 
+    "ogc-12-100r1": {
+        "authors": [
+            "Stephan Meissl"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=54813", 
+        "ogcNumber": "12-100r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-05-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae GML Application Schema - Coverages - GeoTIFF Coverage Encoding Profile"
+    }, 
+    "ogc-12-103r3": {
+        "authors": [
+            "Gobe Hobona", 
+            "Roger Brackin"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51840", 
+        "ogcNumber": "12-103r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-02-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-9 CCI Semantic Mediation Engineering Report"
+    }, 
+    "ogc-12-104r1": {
+        "authors": [
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=52065", 
+        "ogcNumber": "12-104r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-06-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae OWS-9 Engineering Report - CCI - Single Point of Entry Global Gazetteer"
+    }, 
+    "ogc-12-105": {
+        "authors": [
+            "Joan Mas\u00f3"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=52018", 
+        "ogcNumber": "12-105", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-06-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae OWS-9 - OWS Context evaluation IP Engineering Report"
+    }, 
+    "ogc-12-111r1": {
+        "authors": [
+            "Marie-Fran\u00e7oise Voidrot-Martinez", 
+            "Chris Little", 
+            "J\u00fcrgen Seib", 
+            "Roy Ladner", 
+            "Adrian Custer", 
+            "Jeff de La B"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=56394", 
+        "ogcNumber": "12-111r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-04-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Best Practice for using Web Map Services (WMS) with Time-Dependent or Elevation-Dependent Data"
+    }, 
+    "ogc-12-117r1": {
+        "authors": [
+            "Ryosuke Shibasaki"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51623", 
+        "ogcNumber": "12-117r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-12-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Standard for Moving Features; Requirements"
+    }, 
+    "ogc-12-118": {
+        "authors": [
+            "Andreas Matheus"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51806", 
+        "ogcNumber": "12-118", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-02-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-9 Security Engineering Report "
+    }, 
+    "ogc-12-119r1": {
+        "authors": [
+            "Ingo Simonis"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=52272", 
+        "ogcNumber": "12-119r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-02-01", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-9: OGC Mobile Apps: Definition, Requirements, and Information Architecture"
+    }, 
+    "ogc-12-128r10": {
+        "authors": [
+            "Paul Daisey"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=56357", 
+        "ogcNumber": "12-128r10", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-02-10", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae GeoPackage Encoding Standard"
+    }, 
+    "ogc-12-128r12": {
+        "authors": [
+            "Paul Daisey"
+        ], 
+        "href": "http://www.geopackage.org/spec", 
+        "ogcNumber": "12-128r12", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-04-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae GeoPackage Encoding Standard - With Corrigendum"
+    }, 
+    "ogc-12-128r14": {
+        "authors": [
+            "Jeff Yutzler"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=74225", 
+        "ogcNumber": "12-128r14", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-08-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae GeoPackage Encoding Standard"
+    }, 
+    "ogc-12-128r15": {
+        "authors": [
+            "Jeff Yutzler"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=80678", 
+        "ogcNumber": "12-128r15", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-09-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae GeoPackage Encoding Standard - with Corrigendum"
+    }, 
+    "ogc-12-132r4": {
+        "authors": [
+            "Martin Lechner"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=62168", 
+        "ogcNumber": "12-132r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-02-24", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Augmented Reality Markup Language 2.0 (ARML 2.0)"
+    }, 
+    "ogc-12-133": {
+        "authors": [
+            "John Hudson"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51178", 
+        "ogcNumber": "12-133", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-08-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Web Services Facade for OGC IP Engineering Report"
+    }, 
+    "ogc-12-139": {
+        "authors": [
+            "Jan Herrmann", 
+            "Andreas Matheus"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51833", 
+        "ogcNumber": "12-139", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-02-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-9: SSI Security Rules Service Engineering Report"
+    }, 
+    "ogc-12-144": {
+        "authors": [
+            "David Burggraf"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=53255", 
+        "ogcNumber": "12-144", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-06-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae OWS-9 Architecture - Registry Engineering Report"
+    }, 
+    "ogc-12-146": {
+        "authors": [
+            "Timo Thomas"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51811", 
+        "ogcNumber": "12-146", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-06-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae OWS-9 Web Feature Service Temporality Extension Engineering Report"
+    }, 
+    "ogc-12-147": {
+        "authors": [
+            "Claude Speed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51823", 
+        "ogcNumber": "12-147", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-02-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-9 Aviation Architecture Engineering Report"
+    }, 
+    "ogc-12-151": {
+        "authors": [
+            "Daniel Balog", 
+            "Roger Brackin", 
+            "Robin Houtmeyers"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51898", 
+        "ogcNumber": "12-151", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-02-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-9 Aviation Portrayal Engineering Report"
+    }, 
+    "ogc-12-152r1": {
+        "authors": [
+            "Luis Bermudez"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=52112", 
+        "ogcNumber": "12-152r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-06-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae OWS-9 CITE Help Guide Engineering Report"
+    }, 
+    "ogc-12-154": {
+        "authors": [
+            "Darko Androsevic"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51889", 
+        "ogcNumber": "12-154", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-02-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-9 OWS Innovations GMLJP2 for National Imagery Transmission Format (NITF) Engineering Report "
+    }, 
+    "ogc-12-155": {
+        "authors": [
+            "Weiguo Han", 
+            "Yuanzheng Shao", 
+            "Liping Di"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51891", 
+        "ogcNumber": "12-155", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-06-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae OWS-9 OWS Innovations WCS for LIDAR Engineering Report "
+    }, 
+    "ogc-12-156": {
+        "authors": [
+            "George Percivall"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51842", 
+        "ogcNumber": "12-156", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-02-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-9 Reference Architecture Profile (RAP) Advisor Engineering Report"
+    }, 
+    "ogc-12-157": {
+        "authors": [
+            "Joan Mas\u00f3"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=52757", 
+        "ogcNumber": "12-157", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-06-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae OWS-9 Engineering Report - OWS Innovations - Map Tiling Methods Harmonization"
+    }, 
+    "ogc-12-158": {
+        "authors": [
+            "Matthes Rieke"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51817", 
+        "ogcNumber": "12-158", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-06-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae OWS-9 Report on Aviation Performance Study"
+    }, 
+    "ogc-12-159": {
+        "authors": [
+            "Matthes Rieke", 
+            "Benjamin Pross"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51818", 
+        "ogcNumber": "12-159", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-02-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-9 CCI Conflation with Provenance Engineering Report"
+    }, 
+    "ogc-12-160r1": {
+        "authors": [
+            "Jon Blower", 
+            "Xiaoyu Yang", 
+            "Joan Mas\u00f3", 
+            "Simon Thum"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=52884", 
+        "ogcNumber": "12-160r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-06-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae OWS 9 Data Quality and Web Mapping Engineering Report"
+    }, 
+    "ogc-12-162r1": {
+        "authors": [
+            "Jinsongdi Yu", 
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51911", 
+        "ogcNumber": "12-162r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-06-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-9 WCS Conformance Testing Engineering Report"
+    }, 
+    "ogc-12-163": {
+        "authors": [
+            "Thibault Dacla; Eriza Hafid Fazli; Charles Chen; Stuart Wilson"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=51812", 
+        "ogcNumber": "12-163", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-06-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae OWS-9 Data Transmission Management"
+    }, 
+    "ogc-12-168r6": {
+        "authors": [
+            "Douglas Nebert", 
+            "Uwe Voges", 
+            "Lorenzo Bigagli"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/12-168r6/12-168r6.html", 
+        "ogcNumber": "12-168r6", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-06-10", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Catalogue Services 3.0 - General Model"
+    }, 
+    "ogc-12-176r7": {
+        "authors": [
+            "Doug Nebert", 
+            "Uwe Voges", 
+            "Panagiotis Vretanos", 
+            "Lorenzo Bigagli", 
+            "Bruce Westcott"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/12-176r7/12-176r7.html", 
+        "ogcNumber": "12-176r7", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-06-10", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Catalogue Services 3.0 Specification - HTTP Protocol Binding"
+    }, 
+    "ogc-13-011": {
+        "authors": [
+            "Nadine Alameh"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=53036", 
+        "ogcNumber": "13-011", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-04-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OWS-9: Summary of the  OGC Web Services, Phase 9 (OWS-9) Interoperability Testbed"
+    }, 
+    "ogc-13-015": {
+        "authors": [
+            "EO2HEAVEN Consortium"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=52675", 
+        "ogcNumber": "13-015", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-02-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Best Practice for Sensor Web Enablement: Provision of Observations through an OGC Sensor Observation Service (SOS)"
+    }, 
+    "ogc-13-021r3": {
+        "authors": [
+            "Peter Taylor"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=54423", 
+        "ogcNumber": "13-021r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-06-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "WaterML2.0 - part 2: Ratings, Gaugings and Sections Discussion Paper"
+    }, 
+    "ogc-13-026r8": {
+        "authors": [
+            "Pedro Gon\u00e7alves", 
+            "Uwe Voges"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/13-026r8/13-026r8.html", 
+        "ogcNumber": "13-026r8", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-12-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae OpenSearch Extension for Earth Observation"
+    }, 
+    "ogc-13-032": {
+        "authors": [
+            "George Percivall"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=53823", 
+        "ogcNumber": "13-032", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-09-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae SWE Implementation Maturity  Engineering Report"
+    }, 
+    "ogc-13-039": {
+        "authors": [
+            "Nicolas Fanjeau", 
+            "Sebastian Ulrich"
+        ], 
+        "href": "http://docs.opengeospatial.org/bp/13-039/13-039.html", 
+        "ogcNumber": "13-039", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-12-29", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae OpenSearch Extension for Earth Observation Satellite Tasking: Best Practice"
+    }, 
+    "ogc-13-042": {
+        "authors": [
+            "Daniele Marchionni"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=55209", 
+        "ogcNumber": "13-042", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-04-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC RESTful Encoding of Ordering Services Framework For Earth Observation Products"
+    }, 
+    "ogc-13-043": {
+        "authors": [
+            "Daniele Marchionni", 
+            "Raul Cafini"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=55210", 
+        "ogcNumber": "13-043", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-01-31", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Download Service for Earth Observation Products Best Practice"
+    }, 
+    "ogc-13-046r2": {
+        "authors": [
+            "Lew Leinenweber"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=55432", 
+        "ogcNumber": "13-046r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-02-24", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC CHISP-1 Summary Engineering Report"
+    }, 
+    "ogc-13-054r1": {
+        "authors": [
+            "Richard Martell"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=55342", 
+        "ogcNumber": "13-054r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-11-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Summary and Recommendations of the Geospatial Enhancement for the National Information Exchange Model (Geo4NIEM) Interoperabi"
+    }, 
+    "ogc-13-057r1": {
+        "authors": [
+            "Peter Bauman"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/13-057r1/13-057r1.html", 
+        "ogcNumber": "13-057r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-11-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Web Coverage Service Interface Standard \u2013 Transaction Extension"
+    }, 
+    "ogc-13-068": {
+        "authors": [
+            "Pedro Gon\u00e7alves"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=55219", 
+        "ogcNumber": "13-068", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-02-24", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC OpenSearch Extension for Correlated Search"
+    }, 
+    "ogc-13-080r3": {
+        "authors": [
+            "Frank Klucznik", 
+            "Matthew Weber", 
+            "Robin Houtmeyers", 
+            "Roger Brackin"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=55252", 
+        "ogcNumber": "13-080r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-10-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Military Operations Geospatial Interoperability Experiment (MOGIE)"
+    }, 
+    "ogc-13-082r2": {
+        "authors": [
+            "Joan Mas\u00f3"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/13-082r2/13-082r2.html", 
+        "ogcNumber": "13-082r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-01-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Web Map Tile Service (WMTS) Simple Profile"
+    }, 
+    "ogc-13-084r2": {
+        "authors": [
+            "Uwe Voges", 
+            "Fr\u00e9d\u00e9ric Houbie", 
+            "Nicolas Lesage", 
+            "Marie-Lise Vautier"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=56905", 
+        "ogcNumber": "13-084r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-04-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC I15 (ISO19115 Metadata) Extension Package of CS-W ebRIM Profile 1.0"
+    }, 
+    "ogc-13-099": {
+        "authors": [
+            "Jan Herrmann", 
+            "Andreas Matheus"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=55230", 
+        "ogcNumber": "13-099", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-11-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC GeoXACML and XACML  Policy Administration Web Service (PAWS)"
+    }, 
+    "ogc-13-100": {
+        "authors": [
+            "Andreas Matheus"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=55231", 
+        "ogcNumber": "13-100", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-11-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Geospatial eXensible Access Control Markup Language (GeoXACML) 3.0 Core"
+    }, 
+    "ogc-13-101": {
+        "authors": [
+            "Andreas Matheus"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=55232", 
+        "ogcNumber": "13-101", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-11-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Geospatial eXensible Access Control Markup Language (GeoXACML) 3.0 GML 3.2.1 Encoding Extension"
+    }, 
+    "ogc-13-131r1": {
+        "authors": [
+            "Aaron Braeckel", 
+            "Lorenzo Bigagli", 
+            "Johannes Echterhoff"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/13-131r1/13-131r1.html", 
+        "ogcNumber": "13-131r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-08-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Publish/Subscribe Interface Standard 1.0 - Core"
+    }, 
+    "ogc-13-133r1": {
+        "authors": [
+            "Aaron Braeckel", 
+            "Lorenzo Bigagli"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/13-133r1/13-133r1.html", 
+        "ogcNumber": "13-133r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-08-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Publish/Subscribe Interface Standard 1.0 SOAP Protocol Binding Extension"
+    }, 
+    "ogc-130=-053r1": {
+        "authors": [
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=55244", 
+        "ogcNumber": "130=-053r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-02-24", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae CHISP-1 Engineering Report"
+    }, 
+    "ogc-14-000": {
+        "authors": [
+            "R. Martell"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=58995", 
+        "ogcNumber": "14-000", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-07-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed 10 Engineering Report: GML for Aviation Conformance Testing"
+    }, 
+    "ogc-14-001": {
+        "authors": [
+            "Joan Mas\u00f3", 
+            "Guillem Closa Yolanda Gil", 
+            "Benjamin Pro\u00df"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=58967", 
+        "ogcNumber": "14-001", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-07-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 10 Provenance Engineering Report"
+    }, 
+    "ogc-14-002": {
+        "authors": [
+            "Joan Mas\u00f3", 
+            "Raj Singh"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=58965", 
+        "ogcNumber": "14-002", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-07-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 10 Annotations Engineering Report"
+    }, 
+    "ogc-14-003": {
+        "authors": [
+            "Simon J D Cox", 
+            "Bruce A Simons"
+        ], 
+        "href": "http://docs.opengeospatial.org/bp/14-003/14-003.html", 
+        "ogcNumber": "14-003", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-12-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "WaterML-WQ \u2013 an O&M and WaterML 2.0 profile for water quality data"
+    }, 
+    "ogc-14-004": {
+        "authors": [
+            "GEOWOW Consortium"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=57327", 
+        "ogcNumber": "14-004", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-04-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Sensor Observation Service 2.0 Hydrology Profile"
+    }, 
+    "ogc-14-004r1": {
+        "authors": [
+            "Volker Andres", 
+            "Simon Jirka", 
+            "Michael Utech"
+        ], 
+        "href": "http://docs.opengeospatial.org/bp/14-004r1/14-004r1.html", 
+        "ogcNumber": "14-004r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-10-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Sensor Observation Service 2.0 Hydrology Profile"
+    }, 
+    "ogc-14-005r3": {
+        "authors": [
+            "Jiyeong Lee", 
+            "Ki-Joune Li", 
+            "Sisi Zlatanova", 
+            "Thomas H. Kolbe", 
+            "Claus Nagel", 
+            "Thomas Becker"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/14-005r3/14-005r3.html", 
+        "ogcNumber": "14-005r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-12-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae IndoorGML"
+    }, 
+    "ogc-14-006r1": {
+        "authors": [
+            "Daniel Balog"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=59793", 
+        "ogcNumber": "14-006r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-07-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 10 Recommendations for Exchange of Terrain Data"
+    }, 
+    "ogc-14-007": {
+        "authors": [
+            "Matthes Rieke"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=58931", 
+        "ogcNumber": "14-007", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-07-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 10 Report on Aviation Binding AIXM to Development Tools"
+    }, 
+    "ogc-14-008": {
+        "authors": [
+            "Matthes Rieke"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=58927", 
+        "ogcNumber": "14-008", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-07-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 10 Report on Aviation Architecture"
+    }, 
+    "ogc-14-009r1": {
+        "authors": [
+            "Pedro Gon\u00e7alves"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=57477", 
+        "ogcNumber": "14-009r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-04-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed-10 Rules for JSON and GeoJSON Adoption: Focus on OWS-Context"
+    }, 
+    "ogc-14-012r1": {
+        "authors": [
+            "Nicolas FANJEAU", 
+            "Sebastian ULRICH"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=57203", 
+        "ogcNumber": "14-012r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-07-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC RESTful encoding of OGC Sensor Planning Service  for Earth Observation satellite Tasking"
+    }, 
+    "ogc-14-013r1": {
+        "authors": [
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=58892", 
+        "ogcNumber": "14-013r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-05-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed-10 Service Integration Engineering Report"
+    }, 
+    "ogc-14-014r3": {
+        "authors": [
+            "Lorenzo Bigagli", 
+            "Doug Nebert", 
+            "Uwe Voges", 
+            "Panagiotis Vretanos", 
+            "Bruce Westcott"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/14-014r3/14-014r3.html", 
+        "ogcNumber": "14-014r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-06-10", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Catalogue Services Specification - HTTP protocol binding - Abstract Test Suite"
+    }, 
+    "ogc-14-016": {
+        "authors": [
+            "Arne Br\u00f6ring;Simon Jirka;Matthes Rieke", 
+            "Benjamin Pross"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=58925", 
+        "ogcNumber": "14-016", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-07-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed-10 CCI VGI Engineering Report"
+    }, 
+    "ogc-14-017": {
+        "authors": [
+            "Gobe Hobona", 
+            "Roger Brackin"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=57334", 
+        "ogcNumber": "14-017", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-04-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 10 OWS Context in NIEM Engineering Report"
+    }, 
+    "ogc-14-021r2": {
+        "authors": [
+            "Gobe Hobona", 
+            "Roger Brackin"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=57336", 
+        "ogcNumber": "14-021r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-04-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 10 CCI Profile Interoperability Engineering Report"
+    }, 
+    "ogc-14-028r1": {
+        "authors": [
+            "Edric Keighan", 
+            "Benjamin Pross", 
+            "Herv\u00e9 Caumont"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=59618", 
+        "ogcNumber": "14-028r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-10-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed 10 Performance of OGC\u00ae Services in the Cloud: The WMS, WMTS, and WPS cases"
+    }, 
+    "ogc-14-029r2": {
+        "authors": [
+            "Martin Klopfer"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=59336", 
+        "ogcNumber": "14-029r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-07-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 10 Virtual Global Gazetteer Engineering Report"
+    }, 
+    "ogc-14-037": {
+        "authors": [
+            "Thomas Forbes", 
+            "Ballal Joglekar"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=58956", 
+        "ogcNumber": "14-037", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-07-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 10 Flight Information Exchange Model GML Schema"
+    }, 
+    "ogc-14-038r1": {
+        "authors": [
+            "Mark Hughes"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=58117", 
+        "ogcNumber": "14-038r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-07-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 10 Engineering Report:  Aviation Dissemination of Weather Data"
+    }, 
+    "ogc-14-039": {
+        "authors": [
+            "Thibault Dacla", 
+            "Daniel Balog"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=58929", 
+        "ogcNumber": "14-039", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-07-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 10 Aviation Human Factor Based Portrayal of Digital NOTAMs ER"
+    }, 
+    "ogc-14-044": {
+        "authors": [
+            "Lew Leinenweber"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=61108", 
+        "ogcNumber": "14-044", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-02-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 10 Summary Engineering Report"
+    }, 
+    "ogc-14-048": {
+        "authors": [
+            "Genong (Eugene) Yu", 
+            "Liping Di"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=58944", 
+        "ogcNumber": "14-048", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-07-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 10 Cross Community Interoperability (CCI) Hydro Model Interoperability Engineering Report"
+    }, 
+    "ogc-14-049": {
+        "authors": [
+            "Ingo Simonis", 
+            "Stephane Fellah"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=58974", 
+        "ogcNumber": "14-049", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-07-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 10 Cross Community Interoperability (CCI) Ontology Engineering Report"
+    }, 
+    "ogc-14-055r2": {
+        "authors": [
+            "Pedro Gonc&#807;alves", 
+            "Roger Brackin"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=68826", 
+        "ogcNumber": "14-055r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-04-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC OWS Context GeoJSON Encoding Standard"
+    }, 
+    "ogc-14-057": {
+        "authors": [
+            "Bart De Lathouwer", 
+            "Peter Cotroneo", 
+            "Paul Lacey"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=61057", 
+        "ogcNumber": "14-057", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-03-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae and Ordnance Survey - UK Interoperability Assessment Plugfest (UKIAP) Engineering Report "
+    }, 
+    "ogc-14-065": {
+        "authors": [
+            "Matthias Mueller"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/14-065/14-065r0.html", 
+        "ogcNumber": "14-065", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-03-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae WPS 2.0 Interface Standard"
+    }, 
+    "ogc-14-065r1": {
+        "authors": [
+            "Matthias Mueller"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/14-065/14-065r1.html", 
+        "ogcNumber": "14-065r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-10-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae WPS 2.0.1 Interface Standard: Corrigendum 1"
+    }, 
+    "ogc-14-065r2": {
+        "authors": [
+            "Matthias Mueller"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/14-065/14-065r2.html", 
+        "ogcNumber": "14-065r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-02-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae WPS 2.0.2 Interface Standard: Corrigendum 2"
+    }, 
+    "ogc-14-073r1": {
+        "authors": [
+            "George Wilber", 
+            "Johannes Echterhoff", 
+            "Matt de Ris", 
+            "Joshua Lieberman"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/60175", 
+        "ogcNumber": "14-073r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-11-03", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Aircraft Access to SWIM (AAtS) Harmonization Architecture Report"
+    }, 
+    "ogc-14-079r1": {
+        "authors": [
+            "Ingo Simonis"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=59983", 
+        "ogcNumber": "14-079r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-02-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "USGS OGC\u00ae Interoperability Assessment Report"
+    }, 
+    "ogc-14-083r2": {
+        "authors": [
+            "Akinori Asahara", 
+            "Ryosuke Shibasaki", 
+            "Nobuhiro Ishimaru", 
+            "David Burggraf"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/14-083r2/14-083r2.html", 
+        "ogcNumber": "14-083r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-02-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Moving Features Encoding Part I: XML Core"
+    }, 
+    "ogc-14-084r2": {
+        "authors": [
+            "Akinori Asahara", 
+            "Ryosuke Shibasaki", 
+            "Nobuhiro Ishimaru", 
+            "David Burggraf"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/14-084r2/14-084r2.html", 
+        "ogcNumber": "14-084r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-02-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Moving Features Encoding Extension: Simple Comma Separated Values (CSV)"
+    }, 
+    "ogc-14-086r1": {
+        "authors": [
+            "Josh Lieberman", 
+            "Johannes Echterhoff", 
+            "Matt de Ris", 
+            "George Wilber"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/60176", 
+        "ogcNumber": "14-086r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-11-03", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Aircraft Access to SWIM (AAtS) Harmonization Project Summary Report"
+    }, 
+    "ogc-14-095": {
+        "authors": [
+            "Lance McKee"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/60920", 
+        "ogcNumber": "14-095", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-01-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Information Technology Standards for Sustainable Development"
+    }, 
+    "ogc-14-100r2": {
+        "authors": [
+            "Ben Domenico", 
+            "Stefano Nativi"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/14-100r2/14-100r2.html", 
+        "ogcNumber": "14-100r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-11-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae CF-netCDF 3.0 encoding using GML Coverage Application Schema"
+    }, 
+    "ogc-14-106": {
+        "authors": [
+            "Carl Reed", 
+            "Jennifer Harne"
+        ], 
+        "href": "http://docs.opengeospatial.org/bp/14-106/14-106.html", 
+        "ogcNumber": "14-106", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-01-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Unified Geo-data Reference Model for Law Enforcement and Public Safety"
+    }, 
+    "ogc-14-110r2": {
+        "authors": [
+            "Dimitri Sarafinof"
+        ], 
+        "href": "http://docs.opengeospatial.org/bp/14-110r2/14-110r2.html", 
+        "ogcNumber": "14-110r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-11-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae GML Application Schema - Coverages JPEG2000/JPIP Coverage Encoding Extension"
+    }, 
+    "ogc-14-111r6": {
+        "authors": [
+            "David Blodgett", 
+            "Irina Dornblut"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/14-111r6/14-111r6.html", 
+        "ogcNumber": "14-111r6", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae WaterML 2: Part 3 - Surface Hydrology Features (HY_Features) - Conceptual Model"
+    }, 
+    "ogc-14-114r1": {
+        "authors": [
+            "Peter Taylor"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=61224", 
+        "ogcNumber": "14-114r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-12-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "WaterML2.0 part 2 \u2013 rating tables, gauging observations and cross-sections: Interoperability Experiment Results"
+    }, 
+    "ogc-14-115": {
+        "authors": [
+            "George Percivall"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/61188", 
+        "ogcNumber": "14-115", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-01-21", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Smart Cities Spatial Information Framework"
+    }, 
+    "ogc-15-001r4": {
+        "authors": [
+            "Benjamin Hagedorn", 
+            "Simon Thum", 
+            "Thorsten Reitz", 
+            "Voker Coors", 
+            "Ralf Gutbell"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/15-001r4/15-001r4.html", 
+        "ogcNumber": "15-001r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-09-13", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae 3D Portrayal Service 1.0"
+    }, 
+    "ogc-15-002r5": {
+        "authors": [
+            "Luis Bermudez"
+        ], 
+        "href": "http://docs.opengeospatial.org/wp/15-002r5/15-002r5.html", 
+        "ogcNumber": "15-002r5", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-04-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Compliance Overview - Guide for Software Acquisition"
+    }, 
+    "ogc-15-003": {
+        "authors": [
+            "David Graham"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=61935", 
+        "ogcNumber": "15-003", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-07-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Common DataBase Volume 1 Main Body"
+    }, 
+    "ogc-15-004": {
+        "authors": [
+            "David Graham"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=61936", 
+        "ogcNumber": "15-004", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-07-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Common DataBase Volume 2 Appendices"
+    }, 
+    "ogc-15-005r1": {
+        "authors": [
+            "Stefan Strobel", 
+            "Dimitri Sarafinof", 
+            "David Wesloh", 
+            "Paul Lacey"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=66933", 
+        "ogcNumber": "15-005r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-02-01", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "DGIWG - Web Feature Service 2.0 Profile"
+    }, 
+    "ogc-15-010r4": {
+        "authors": [
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=66905", 
+        "ogcNumber": "15-010r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-01-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed-11 WFS-T Information Exchange Architecture"
+    }, 
+    "ogc-15-011r2": {
+        "authors": [
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=66906", 
+        "ogcNumber": "15-011r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-01-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-11 Multiple WFS-T Interoperability"
+    }, 
+    "ogc-15-012r2": {
+        "authors": [
+            "Jeff Yutzler"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=63285", 
+        "ogcNumber": "15-012r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-08-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC GeoPackage Plugfest Discussion Paper"
+    }, 
+    "ogc-15-018r2": {
+        "authors": [
+            "Peter Taylor"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/15-018r2/15-018r2.html", 
+        "ogcNumber": "15-018r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-02-03", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC WaterML2.0: part 2 - Ratings, Gaugings and Sections"
+    }, 
+    "ogc-15-022": {
+        "authors": [
+            "Andreas Matheus"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=63312", 
+        "ogcNumber": "15-022", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-08-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 11 Engineering Report: Implementing Common Security Across the OGC Suite of Service Standards"
+    }, 
+    "ogc-15-024r2": {
+        "authors": [
+            "Johannes Echterhoff"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=63794", 
+        "ogcNumber": "15-024r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-08-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 11 Aviation - Guidance on Using Semantics of Business Vocabulary and Business Rules (SBVR) Engineering Report"
+    }, 
+    "ogc-15-025r2": {
+        "authors": [
+            "Johannes Echterhoff"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=63793", 
+        "ogcNumber": "15-025r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-08-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 11 Aviation - Architecture Engineering Report"
+    }, 
+    "ogc-15-026": {
+        "authors": [
+            "Thomas Forbes", 
+            "Alberto Olivares", 
+            "Richard Rombouts"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=63306", 
+        "ogcNumber": "15-026", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-10-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed-11 Aviation Feature Schema Recommendations Engineering Report"
+    }, 
+    "ogc-15-027r1": {
+        "authors": [
+            "Aleksandar Balaban"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=64141", 
+        "ogcNumber": "15-027r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-01-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 11 Digital Notice to Airmen (NOTAM) Validation and Enrichment Service Engineering Report"
+    }, 
+    "ogc-15-028": {
+        "authors": [
+            "Daniel Balog"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=63281", 
+        "ogcNumber": "15-028", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-08-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 11 Data Broker Specifications Engineering Report"
+    }, 
+    "ogc-15-030r3": {
+        "authors": [
+            "Scott Serich"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=65451", 
+        "ogcNumber": "15-030r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-01-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed 11 Geospatial Enhancement for the National Information Exchange Model (Geo4NIEM) Round Trip Engineering Report"
+    }, 
+    "ogc-15-037": {
+        "authors": [
+            "George Percivall"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=63334", 
+        "ogcNumber": "15-037", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-10-01", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC IOGP/IPIECA Recommended Practice for a Common Operating Picture for Oil Spill Response"
+    }, 
+    "ogc-15-039": {
+        "authors": [
+            "Jeff Yutzler"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=63289", 
+        "ogcNumber": "15-039", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-08-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Envisioning a Tiled Elevation Extension for the OGC GeoPackage Encoding Standard"
+    }, 
+    "ogc-15-042r3": {
+        "authors": [
+            "James Tomkins", 
+            "Dominic Lowe"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/15-042r3/15-042r3.html", 
+        "ogcNumber": "15-042r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-09-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "TimeseriesML 1.0 \u2013 XML Encoding of the Timeseries Profile of Observations and Measurements"
+    }, 
+    "ogc-15-042r5": {
+        "authors": [
+            "James Tomkins", 
+            "Dominic Lowe"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/15-042r5/15-042r5.html", 
+        "ogcNumber": "15-042r5", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-12-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC TimeseriesML 1.2 \u2013 XML Encoding of the Timeseries Profile of Observations and Measurements"
+    }, 
+    "ogc-15-043r3": {
+        "authors": [
+            "James Tomkins", 
+            "Dominic Lowe"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/15-043r3/15-043r3.html", 
+        "ogcNumber": "15-043r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-09-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Timeseries Profile of Observations and Measurements "
+    }, 
+    "ogc-15-046r2": {
+        "authors": [
+            "Eugene G. Yu", 
+            "Liping Di", 
+            "Ranjay Shrestha"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=64174", 
+        "ogcNumber": "15-046r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-01-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed-11 High Resolution Flood Information Scenario Engineering Report"
+    }, 
+    "ogc-15-047r3": {
+        "authors": [
+            "Jeff Harrison"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=65418", 
+        "ogcNumber": "15-047r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-01-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-11 NIEM-IC Feature Processing API using OGC Web Services"
+    }, 
+    "ogc-15-048r3": {
+        "authors": [
+            "Jeff Harrison"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=65420", 
+        "ogcNumber": "15-048r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-01-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-11 NIEM & IC Data Encoding Specification Assessment and Recommendations Engineering Report"
+    }, 
+    "ogc-15-050r3": {
+        "authors": [
+            "Jeff Harrison"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=65421", 
+        "ogcNumber": "15-050r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-01-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-11 Test and Demonstration Results for NIEM using IC Data Encoding Specifications Engineering Report"
+    }, 
+    "ogc-15-051r3": {
+        "authors": [
+            "Jeff Harrison"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=65419", 
+        "ogcNumber": "15-051r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-01-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-11 OGC IP Engineering Report Geo4NIEM Architecture Design and Implementation Guidance and Fact Sheet "
+    }, 
+    "ogc-15-052r1": {
+        "authors": [
+            "Fr\u00e9d\u00e9ric Houbie"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=64860", 
+        "ogcNumber": "15-052r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-01-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 11 REST Interface Engineering Report"
+    }, 
+    "ogc-15-053r1": {
+        "authors": [
+            "Joan Mas\u00f3"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=64595", 
+        "ogcNumber": "15-053r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-08-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 11 Implementing JSON/GeoJSON in an OGC Standard Engineering Report"
+    }, 
+    "ogc-15-054": {
+        "authors": [
+            "Stephane Fellah"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=64405", 
+        "ogcNumber": "15-054", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-11-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed-11 Implementing Linked Data and Semantically Enabling OGC Services Engineering Report"
+    }, 
+    "ogc-15-056": {
+        "authors": [
+            "Wenwen Li", 
+            "Sheng Wu"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=64382", 
+        "ogcNumber": "15-056", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-10-01", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 11 Catalogue Service and Discovery Engineering Report "
+    }, 
+    "ogc-15-057r2": {
+        "authors": [
+            "Matthes Rieke", 
+            "Simon Jirka", 
+            "Stephane Fellah"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=64353", 
+        "ogcNumber": "15-057r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-11-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed-11 Incorporating Social Media in Emergency Response Engineering Report"
+    }, 
+    "ogc-15-058": {
+        "authors": [
+            "Stephane Fellah"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=64385", 
+        "ogcNumber": "15-058", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-11-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed-11 Symbology Mediation"
+    }, 
+    "ogc-15-065r1": {
+        "authors": [
+            "Eric Hirschorn", 
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=64145", 
+        "ogcNumber": "15-065r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-11-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed11 Referenceable Grid Harmonization Engineering Report"
+    }, 
+    "ogc-15-066r1": {
+        "authors": [
+            "Gobe Hobona;Roger Brackin"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=64173", 
+        "ogcNumber": "15-066r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-10-01", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 11 Use of Semantic Linked Data with RDF for National Map NHD and Gazetteer Data Engineering Report "
+    }, 
+    "ogc-15-067": {
+        "authors": [
+            "Gobe Hobona;Roger Brackin"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=63663", 
+        "ogcNumber": "15-067", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-11-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed-11 Multi-dimensional GeoPackage Supporting Terrain and Routes Engineering Report"
+    }, 
+    "ogc-15-068r2": {
+        "authors": [
+            "Gobe Hobona;Roger Brackin"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=64189", 
+        "ogcNumber": "15-068r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-08-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed 11 GeoPackaging Engineering Report"
+    }, 
+    "ogc-15-073": {
+        "authors": [
+            "E. Devys", 
+            "L.Colaiacomo", 
+            "P. Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=65887", 
+        "ogcNumber": "15-073", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-11-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed-11 DGIWG GMLJP2 testing results Engineering Report"
+    }, 
+    "ogc-15-074": {
+        "authors": [
+            "Frans Knibbe", 
+            "Alejandro Llaves"
+        ], 
+        "href": "http://docs.opengeospatial.org/dp/15-074/15-074.html", 
+        "ogcNumber": "15-074", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-07-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Spatial Data on the Web Use Cases & Requirements"
+    }, 
+    "ogc-15-074r1": {
+        "authors": [
+            "Frans Knibbe", 
+            "Alejandro Llaves"
+        ], 
+        "href": "http://docs.opengeospatial.org/dp/15-074r1/15-074r1.html", 
+        "ogcNumber": "15-074r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-12-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Spatial Data on the Web Use Cases & Requirements"
+    }, 
+    "ogc-15-074r2": {
+        "authors": [
+            "Frans Knibbe", 
+            "Alejandro Llaves"
+        ], 
+        "href": "http://docs.opengeospatial.org/dp/15-074r2/15-074r2.html", 
+        "ogcNumber": "15-074r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-10-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Spatial Data on the Web Use Cases & Requirements"
+    }, 
+    "ogc-15-075r1": {
+        "authors": [
+            "Ki-Joune Li", 
+            "Hyung-Gyu Ryu", 
+            "Taehoon Kim", 
+            "Hack-Cheol Kim"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=64644", 
+        "ogcNumber": "15-075r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-11-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "A Use-Case for Mobile Location Services with IndoorGML - Indoor Navigation for Visually Impaired People"
+    }, 
+    "ogc-15-077r1": {
+        "authors": [
+            "Ingo Simonis"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=64406", 
+        "ogcNumber": "15-077r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-02-03", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Testbed-11 SOAP Interface Engineering Report: Comparison on the Usage of SOAP Across OGC Web service interfaces"
+    }, 
+    "ogc-15-078r6": {
+        "authors": [
+            "Steve Liang", 
+            "Chih-Yuan Huang", 
+            "Tania Khalafbeigi"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/15-078r6/15-078r6.html", 
+        "ogcNumber": "15-078r6", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-07-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC SensorThings API Part 1: Sensing"
+    }, 
+    "ogc-15-082": {
+        "authors": [
+            "Boyan Brodaric"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=64688", 
+        "ogcNumber": "15-082", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-04-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC GroundWaterML 2 \u2013 GW2IE FINAL REPORT"
+    }, 
+    "ogc-15-096": {
+        "authors": [
+            "Akinori Asahara", 
+            "Hideki Hayashi", 
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=64623", 
+        "ogcNumber": "15-096", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-01-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Use Cases and Applications of the OGC Moving Features Standard: The Requirements for a Moving Feature API"
+    }, 
+    "ogc-15-097r1": {
+        "authors": [
+            "Joan Mas\u00f3", 
+            "Lucy Bastin"
+        ], 
+        "href": "http://docs.opengeospatial.org/dp/15-097r1/15-097r1.html", 
+        "ogcNumber": "15-097r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-12-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Geospatial User Feedback Standard: Conceptual Model"
+    }, 
+    "ogc-15-098r1": {
+        "authors": [
+            "Joan Mas\u00f3", 
+            "Lucy Bastin"
+        ], 
+        "href": "http://docs.opengeospatial.org/dp/15-098r1/15-098r1.html", 
+        "ogcNumber": "15-098r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-12-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Geospatial User Feedback Standard: XML Encoding Extension"
+    }, 
+    "ogc-15-100r1": {
+        "authors": [
+            "Simon J D Cox", 
+            "Peter Taylor"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=64910", 
+        "ogcNumber": "15-100r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2015-12-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Observations and Measurements \u2013 JSON implementation"
+    }, 
+    "ogc-15-104r5": {
+        "authors": [
+            "Matthew Purss"
+        ], 
+        "href": "http://docs.opengeospatial.org/as/15-104r5/15-104r5.html", 
+        "ogcNumber": "15-104r5", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-08-01", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 21: Discrete Global Grid Systems Abstract Specification"
+    }, 
+    "ogc-15-107": {
+        "authors": [
+            "Jeremy Tandy", 
+            "Linda van den Brink", 
+            "Payam Barnaghi"
+        ], 
+        "href": "https://www.w3.org/TR/sdw-bp/", 
+        "ogcNumber": "15-107", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-09-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Spatial Data on the Web Best Practices"
+    }, 
+    "ogc-15-111r1": {
+        "authors": [
+            "Paul Scarponcini"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/15-111r1/15-111r1.html", 
+        "ogcNumber": "15-111r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-12-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Land and Infrastructure Conceptual Model Standard (LandInfra)"
+    }, 
+    "ogc-15-112r2": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=72714", 
+        "ogcNumber": "15-112r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-02-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 3: OGC CDB Terms and Definitions"
+    }, 
+    "ogc-15-112r3": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/15-112r3", 
+        "ogcNumber": "15-112r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-12-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 3: OGC CDB Terms and Definitions"
+    }, 
+    "ogc-15-113r3": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=72712", 
+        "ogcNumber": "15-113r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-02-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 1: OGC CDB Core Standard: Model and Physical Data Store Structure"
+    }, 
+    "ogc-15-113r5": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/15-113r5", 
+        "ogcNumber": "15-113r5", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-12-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 1: OGC CDB Core Standard: Model and Physical Data Store Structure"
+    }, 
+    "ogc-15-116": {
+        "authors": [
+            "Giuseppe Conti", 
+            "Fabio Roncato"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=68040", 
+        "ogcNumber": "15-116", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-04-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "AHA-ML (Active and Healthy Ageing Mark-up Language) an O&M profile - Discussion Paper"
+    }, 
+    "ogc-15-118r1": {
+        "authors": [
+            "Simon Jirka", 
+            "Christoph Stasch"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/15-118r1.html", 
+        "ogcNumber": "15-118r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-04-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Incident Management Information Sharing Profile Recommendations for OGC Web Services Engineering Report"
+    }, 
+    "ogc-15-120r4": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=72711", 
+        "ogcNumber": "15-120r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-02-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 0: Primer for the OGC CDB Standard: Model and Physical Data Store Structure"
+    }, 
+    "ogc-15-120r5": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=82376", 
+        "ogcNumber": "15-120r5", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-12-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 0: Primer for the OGC CDB Standard: Model and Physical Data Store Structure"
+    }, 
+    "ogc-15-122r1": {
+        "authors": [
+            "Randolph Gladish"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=66606", 
+        "ogcNumber": "15-122r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-04-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Implications for an OGC GeoPackage  Symbology Encoding Standard"
+    }, 
+    "ogc-16-003r2": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=72724", 
+        "ogcNumber": "16-003r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-02-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 12: OGC CDB Navaids Attribution and Navaids Attribution Enumeration Values"
+    }, 
+    "ogc-16-003r3": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/16-003r3", 
+        "ogcNumber": "16-003r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-12-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 12: OGC CDB Navaids Attribution and Navaids Attribution Enumeration Values"
+    }, 
+    "ogc-16-004r3": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=72716", 
+        "ogcNumber": "16-004r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-02-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 5: OGC CDB Radar Cross Section (RCS) Models"
+    }, 
+    "ogc-16-004r4": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/16-004r4", 
+        "ogcNumber": "16-004r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-12-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 5: OGC CDB Radar Cross Section (RCS) Models"
+    }, 
+    "ogc-16-005r2": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=72713", 
+        "ogcNumber": "16-005r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-02-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 2: OGC CDB Core: Model and Physical Structure: Informative Annexes"
+    }, 
+    "ogc-16-005r3": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/16-005r3", 
+        "ogcNumber": "16-005r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-12-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 2: OGC CDB Core: Model and Physical Structure: Informative Annexes"
+    }, 
+    "ogc-16-006r3": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=72722", 
+        "ogcNumber": "16-006r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-02-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 10: OGC CDB Implementation Guidance"
+    }, 
+    "ogc-16-006r4": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/16-006r4", 
+        "ogcNumber": "16-006r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-12-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 10: OGC CDB Implementation Guidance"
+    }, 
+    "ogc-16-007r3": {
+        "authors": [
+            "Sara Saeedi"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=72723", 
+        "ogcNumber": "16-007r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-02-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 11: OGC CDB Core Standard Conceptual Model"
+    }, 
+    "ogc-16-007r4": {
+        "authors": [
+            "Sara Saeedi"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/16-007r4", 
+        "ogcNumber": "16-007r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-12-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 11: OGC CDB Core Standard Conceptual Model"
+    }, 
+    "ogc-16-008": {
+        "authors": [
+            "GeoSciML Modeling Team"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/16-008/16-008.html", 
+        "ogcNumber": "16-008", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-01-31", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Geoscience Markup Language 4.1 (GeoSciML)"
+    }, 
+    "ogc-16-008r1": {
+        "authors": [
+            "eoSciML Modeling Team"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/16-008/16-008r1.html", 
+        "ogcNumber": "16-008r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-01-31", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Geoscience Markup Language 4.1 (GeoSciML) - with Corrigendum"
+    }, 
+    "ogc-16-009r3": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=72717", 
+        "ogcNumber": "16-009r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-02-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 6: OGC CDB Rules for Encoding Data using OpenFlight"
+    }, 
+    "ogc-16-009r4": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/16-009r4", 
+        "ogcNumber": "16-009r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-12-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 6: OGC CDB Rules for Encoding Data using OpenFlight"
+    }, 
+    "ogc-16-010r3": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=72718", 
+        "ogcNumber": "16-010r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-02-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 7: OGC CDB Data Model Guidance Formerly Annex A Volume Part 2"
+    }, 
+    "ogc-16-010r4": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/16-010r4", 
+        "ogcNumber": "16-010r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-12-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 7: OGC CDB Data Model Guidance Formerly Annex A Volume Part 2"
+    }, 
+    "ogc-16-011r3": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=72719", 
+        "ogcNumber": "16-011r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-02-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 8: CDB Spatial and Coordinate Reference Systems Guidance"
+    }, 
+    "ogc-16-011r4": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/16-011r4", 
+        "ogcNumber": "16-011r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-12-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 8: CDB Spatial and Coordinate Reference Systems Guidance"
+    }, 
+    "ogc-16-012r1": {
+        "authors": [
+            "Ki-Joune Li", 
+            "Hyung-Gyu Ryu", 
+            "Hak-Cheol Kim", 
+            "Jun Hee Lee", 
+            "Joo-Ho Lee"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=68824", 
+        "ogcNumber": "16-012r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-12-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Comparing CityGML and IndoorGML based on a use case at Lotte World Mall"
+    }, 
+    "ogc-16-014r2": {
+        "authors": [
+            "Greg Schumann", 
+            "Josh Lieberman"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-014r2.html", 
+        "ogcNumber": "16-014r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-04-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Incident Management Information Sharing (IMIS) Internet of Things (IoT) Architecture Engineering Report"
+    }, 
+    "ogc-16-017": {
+        "authors": [
+            "Matthes Rieke", 
+            "Aleksandar Balaban"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-017.html", 
+        "ogcNumber": "16-017", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-04-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Asynchronous Messaging for Aviation"
+    }, 
+    "ogc-16-018": {
+        "authors": [
+            "Charles Chen"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-018.html", 
+        "ogcNumber": "16-018", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-06-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Aviation Architecture Engineering Report"
+    }, 
+    "ogc-16-019r4": {
+        "authors": [
+            "George Percivall"
+        ], 
+        "href": "http://docs.opengeospatial.org/wp/16-019r4/16-019r4.html", 
+        "ogcNumber": "16-019r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-02-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Open Geospatial APIs - White Paper"
+    }, 
+    "ogc-16-020": {
+        "authors": [
+            "Johannes Echterhoff"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-020.html", 
+        "ogcNumber": "16-020", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-04-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 ShapeChange Engineering Report"
+    }, 
+    "ogc-16-021r1": {
+        "authors": [
+            "Benjamin Pross"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-021r1.html", 
+        "ogcNumber": "16-021r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-05-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Low Bandwidth & Generalization Engineering Report"
+    }, 
+    "ogc-16-022": {
+        "authors": [
+            "Benjamin Pross"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-022.html", 
+        "ogcNumber": "16-022", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-06-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 WPS Conflation Service Profile Engineering Report"
+    }, 
+    "ogc-16-023r3": {
+        "authors": [
+            "Benjamin Pross"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-023r3.html", 
+        "ogcNumber": "16-023r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-06-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Implementing Asynchronous Services Response Engineering Report"
+    }, 
+    "ogc-16-024r2": {
+        "authors": [
+            "R. Martell"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-024r2.html", 
+        "ogcNumber": "16-024r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-06-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12\u2009\u2014\u2009Catalog Services for Aviation"
+    }, 
+    "ogc-16-027": {
+        "authors": [
+            "Johannes Echterhoff", 
+            "Clemens Portele"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-027.html", 
+        "ogcNumber": "16-027", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-05-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Web Service Implementation Engineering Report"
+    }, 
+    "ogc-16-028r1": {
+        "authors": [
+            "Thomas Disney"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-028r1.html", 
+        "ogcNumber": "16-028r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-06-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 FIXM GML Engineering Report"
+    }, 
+    "ogc-16-029r1": {
+        "authors": [
+            "Jeff Yutzler"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-029r1.html", 
+        "ogcNumber": "16-029r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-05-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 GeoPackage Routing and Symbology Engineering Report"
+    }, 
+    "ogc-16-030": {
+        "authors": [
+            "Jeff Yutzler"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-030.html", 
+        "ogcNumber": "16-030", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-05-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Testbed-12 GeoPackage Mobile Apps Integration Engineering Report"
+    }, 
+    "ogc-16-031r1": {
+        "authors": [
+            "Jeff Yutzler"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-031r1.html", 
+        "ogcNumber": "16-031r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-05-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 GeoPackage Change Request Evaluations"
+    }, 
+    "ogc-16-032r2": {
+        "authors": [
+            "Boyan Brodaric"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/16-032r2/16-032r2.html", 
+        "ogcNumber": "16-032r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-03-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC WaterML 2: Part 4 \u2013 GroundWaterML 2 (GWML2)"
+    }, 
+    "ogc-16-033r1": {
+        "authors": [
+            "Ranjay Shrestha", 
+            "Liping Di", 
+            "Eugene G. Yu"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-033r1.html", 
+        "ogcNumber": "16-033r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-04-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 WCS Profile Update Engineering Report"
+    }, 
+    "ogc-16-034": {
+        "authors": [
+            "Simon Jirka", 
+            "Arne de Wall", 
+            "Christoph Stasch"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-034.html", 
+        "ogcNumber": "16-034", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-03-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 LiDAR Streaming Engineering Report"
+    }, 
+    "ogc-16-035": {
+        "authors": [
+            "Christoph Stasch", 
+            "Simon Jirka"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-035.html", 
+        "ogcNumber": "16-035", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-05-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 REST Architecture Engineering Report"
+    }, 
+    "ogc-16-036r1": {
+        "authors": [
+            "Christian Autermann"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-036r1.html", 
+        "ogcNumber": "16-036r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-06-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Big Data Database Engineering Report"
+    }, 
+    "ogc-16-037": {
+        "authors": [
+            "Robert Cass"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-037.html", 
+        "ogcNumber": "16-037", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-05-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 GeoPackage US Topo Engineering Report"
+    }, 
+    "ogc-16-038": {
+        "authors": [
+            "Chris Clark"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-038.html", 
+        "ogcNumber": "16-038", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-05-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 NSG GeoPackage Profile Assessment Engineering Report"
+    }, 
+    "ogc-16-039r2": {
+        "authors": [
+            "Aleksandar Balaban"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-039r2.html", 
+        "ogcNumber": "16-039r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-06-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Aviation Semantics Engineering Report"
+    }, 
+    "ogc-16-040r1": {
+        "authors": [
+            "Aleksandar Balaban"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-040r1.html", 
+        "ogcNumber": "16-040r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-06-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Aviation Security Engineering Report"
+    }, 
+    "ogc-16-041r1": {
+        "authors": [
+            "Liping Di", 
+            "Eugene G. Yu", 
+            "Md Shahinoor Rahman", 
+            "Ranjay Shrestha"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-041r1.html", 
+        "ogcNumber": "16-041r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-06-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 WPS ISO Data Quality Service Profile Engineering Report"
+    }, 
+    "ogc-16-042r1": {
+        "authors": [
+            "Lingjun Kang", 
+            "Liping Di", 
+            "Eugene Yu"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-042r1.html", 
+        "ogcNumber": "16-042r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-06-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 WMS/WMTS Enhanced Engineering Report"
+    }, 
+    "ogc-16-043": {
+        "authors": [
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-043.html", 
+        "ogcNumber": "16-043", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-03-10", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Web Integration Service"
+    }, 
+    "ogc-16-044": {
+        "authors": [
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-044.html", 
+        "ogcNumber": "16-044", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-03-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Web Feature Service Synchronization"
+    }, 
+    "ogc-16-045r2": {
+        "authors": [
+            "Daniel Balog", 
+            "Robin Houtmeyers"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-045r2.html", 
+        "ogcNumber": "16-045r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-06-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Data Broker Engineering Report"
+    }, 
+    "ogc-16-046r1": {
+        "authors": [
+            "Martin Klopfer"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-046r1.html", 
+        "ogcNumber": "16-046r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-05-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Semantic Enablement Engineering Report"
+    }, 
+    "ogc-16-047r1": {
+        "authors": [
+            "Martin Klopfer"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-047r1.html", 
+        "ogcNumber": "16-047r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-05-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 General Feature Model Engineering Report"
+    }, 
+    "ogc-16-048r1": {
+        "authors": [
+            "Andreas Matheus"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-048r1.html", 
+        "ogcNumber": "16-048r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-03-10", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 OWS Common Security Extension ER"
+    }, 
+    "ogc-16-049r1": {
+        "authors": [
+            "Joan Mas\u00f3"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-049r1.html", 
+        "ogcNumber": "16-049r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-06-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Multi-Tile Retrieval ER"
+    }, 
+    "ogc-16-050": {
+        "authors": [
+            "Joan Mas\u00f3", 
+            "Alaitz Zabala"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-050.html", 
+        "ogcNumber": "16-050", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-05-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Imagery Quality and Accuracy Engineering Report"
+    }, 
+    "ogc-16-051": {
+        "authors": [
+            "Joan Mas\u00f3"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-051.html", 
+        "ogcNumber": "16-051", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-05-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Javascript-JSON-JSON-LD Engineering Report"
+    }, 
+    "ogc-16-052": {
+        "authors": [
+            "Joan Mas\u00f3"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-052.html", 
+        "ogcNumber": "16-052", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-05-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 OWS Context / Capabilities Engineering Report"
+    }, 
+    "ogc-16-053r1": {
+        "authors": [
+            "Joan Mas\u00f3"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-053r1.html", 
+        "ogcNumber": "16-053r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-06-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 OWS Context: JSON, JSON-LD and HTML5 ER"
+    }, 
+    "ogc-16-055": {
+        "authors": [
+            "Jeff Harrison"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-055.html", 
+        "ogcNumber": "16-055", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-05-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Compression Techniques Engineering Report"
+    }, 
+    "ogc-16-056": {
+        "authors": [
+            "Jeff Harrison"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-056.html", 
+        "ogcNumber": "16-056", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-05-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 TopoJSON, GML Engineering Report"
+    }, 
+    "ogc-16-059": {
+        "authors": [
+            "Stephane Fellah"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-059.html", 
+        "ogcNumber": "16-059", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-06-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Semantic Portrayal, Registry and Mediation Engineering Report"
+    }, 
+    "ogc-16-060r2": {
+        "authors": [
+            "Daniel Lee"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/16-060r2/16-060r2.html", 
+        "ogcNumber": "16-060r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-11-27", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC GML Application Schema \u2013 Coverages : GRIB2 Coverage Encoding Profile"
+    }, 
+    "ogc-16-061": {
+        "authors": [
+            "Timo Thomas", 
+            "Aleksandar Balaban"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-061.html", 
+        "ogcNumber": "16-061", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-06-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Aviation SBVR Engineering Report"
+    }, 
+    "ogc-16-062": {
+        "authors": [
+            "Gobe Hobona", 
+            "Roger Brackin"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-062.html", 
+        "ogcNumber": "16-062", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-05-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Catalogue and SPARQL Engineering Report"
+    }, 
+    "ogc-16-063": {
+        "authors": [
+            "Stefano Cavazzi", 
+            "Roger Brackin"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-063.html", 
+        "ogcNumber": "16-063", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-03-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Arctic Spatial Data Infrastructure Engineering Report"
+    }, 
+    "ogc-16-064r1": {
+        "authors": [
+            "Detlev Wagner", 
+            "Hugo Ledoux"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=68821", 
+        "ogcNumber": "16-064r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-08-01", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae CityGML Quality Interoperability Experiment"
+    }, 
+    "ogc-16-067r4": {
+        "authors": [
+            "Daniel Balog", 
+            "Robin Houtmeyers"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-067r4.html", 
+        "ogcNumber": "16-067r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-05-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Vector Tiling Implementation Engineering Report"
+    }, 
+    "ogc-16-068r4": {
+        "authors": [
+            "Daniel Balog", 
+            "Robin Houtmeyers"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-068r4.html", 
+        "ogcNumber": "16-068r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-06-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 Vector Tiling Engineering Report"
+    }, 
+    "ogc-16-070r2": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=72715", 
+        "ogcNumber": "16-070r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-02-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 4: OGC CDB Best Practice use of Shapefiles for Vector Data Storage"
+    }, 
+    "ogc-16-070r3": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/16-070r3", 
+        "ogcNumber": "16-070r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-12-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Volume 4: OGC CDB Best Practice use of Shapefiles for Vector Data Storage"
+    }, 
+    "ogc-16-079": {
+        "authors": [
+            "Armin Haller", 
+            "Krzysztof Janowicz", 
+            "Simon Cox", 
+            "Danh Le Phuoc", 
+            "Kerry Taylor", 
+            "Maxime Lefran\u00e7ois"
+        ], 
+        "href": "https://www.w3.org/TR/vocab-ssn/", 
+        "ogcNumber": "16-079", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-09-23", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Semantic Sensor Network Ontology"
+    }, 
+    "ogc-16-083r2": {
+        "authors": [
+            "Eric Hirschorn"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/16-083r2/16-083r2.html", 
+        "ogcNumber": "16-083r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-06-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Coverage Implementation Schema - ReferenceableGridCoverage Extension"
+    }, 
+    "ogc-16-083r3": {
+        "authors": [
+            "Eric Hirschorn"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/16-083r3/16-083r3.html", 
+        "ogcNumber": "16-083r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-01-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Coverage Implementation Schema - ReferenceableGridCoverage Extension with Corrigendum"
+    }, 
+    "ogc-16-084": {
+        "authors": [
+            "Giuseppe Conti", 
+            "Fabio Malabocchia", 
+            "Ki-Joune Li", 
+            "George Percivall", 
+            "Kirk Burroughs", 
+            "Stuart Strickland"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=68604", 
+        "ogcNumber": "16-084", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-08-01", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Benefits of Indoor Location -  Use Case Survey of Lessons Learned and Expectations "
+    }, 
+    "ogc-16-086r3": {
+        "authors": [
+            "J\u00fcrgen Seib", 
+            "Marie-Fran\u00e7oise Voidrot-Martinez", 
+            "Chris Little"
+        ], 
+        "href": "http://docs.opengeospatial.org/bp/16-086r3/16-086r3.html", 
+        "ogcNumber": "16-086r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-04-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Best Practice for using Web Map Services (WMS) with Ensembles of Forecast Data"
+    }, 
+    "ogc-16-088r1": {
+        "authors": [
+            "Alistair Ritchie"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=69896", 
+        "ogcNumber": "16-088r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-07-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Soil Data Interoperability Experiment"
+    }, 
+    "ogc-16-092r2": {
+        "authors": [
+            "Roger Brackin"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-092r2.html", 
+        "ogcNumber": "16-092r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Incident Management Information Sharing (IMIS) Internet of Things (IoT) Extension Engineering Report"
+    }, 
+    "ogc-16-093r1": {
+        "authors": [
+            "Steve Liang", 
+            "Tania Khalafbeigi"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-093r1.html", 
+        "ogcNumber": "16-093r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-04-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Incident Management Information Sharing Internet of Things Protocol Mapping Engineering Report"
+    }, 
+    "ogc-16-094r3": {
+        "authors": [
+            "Micah Brachman"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=70051", 
+        "ogcNumber": "16-094r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-08-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC GeoPackage Elevation Extension Interoperability Experiment Engineering Report"
+    }, 
+    "ogc-16-097": {
+        "authors": [
+            "Mohsen Kalantari"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-097.html", 
+        "ogcNumber": "16-097", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-10-03", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Future City Pilot 1: Using IFC/CityGML in Urban Planning Engineering Report"
+    }, 
+    "ogc-16-098": {
+        "authors": [
+            "Kanishk Chaturvedi", 
+            "Thomas H. Kolbe"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-098.html", 
+        "ogcNumber": "16-098", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-10-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Future City Pilot 1 Engineering Report"
+    }, 
+    "ogc-16-099": {
+        "authors": [
+            "Mohsen Kalantari"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-099.html", 
+        "ogcNumber": "16-099", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-10-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Future City Pilot 1 - Automating Urban Planning Using Web Processing Service Engineering Report"
+    }, 
+    "ogc-16-100r2": {
+        "authors": [
+            "Paul Scarponcini"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=75117", 
+        "ogcNumber": "16-100r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-08-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC InfraGML 1.0: Part 0 \u2013 LandInfra Core - Encoding Standard"
+    }, 
+    "ogc-16-101r2": {
+        "authors": [
+            "Paul Scarponcini"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=75118", 
+        "ogcNumber": "16-101r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-08-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC InfraGML 1.0: Part 1 \u2013 LandInfra Land Features - Encoding Standard"
+    }, 
+    "ogc-16-102r2": {
+        "authors": [
+            "Paul Scarponcini"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=75119", 
+        "ogcNumber": "16-102r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-08-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC InfraGML 1.0: Part 2 - LandInfra Facilities and Projects - Encoding Standard"
+    }, 
+    "ogc-16-103r2": {
+        "authors": [
+            "Paul Scarponcini"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=75120", 
+        "ogcNumber": "16-103r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-08-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC InfraGML 1.0: Part 3 - Alignments - Encoding Standard"
+    }, 
+    "ogc-16-104r2": {
+        "authors": [
+            "Paul Scarponcini"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=75121", 
+        "ogcNumber": "16-104r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-08-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC InfraGML 1.0: Part 4 - LandInfra Roads - Encoding Standard"
+    }, 
+    "ogc-16-105r2": {
+        "authors": [
+            "Peter Axelsson", 
+            "Lars Wikstro\u0308m"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=75122", 
+        "ogcNumber": "16-105r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-08-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC InfraGML 1.0: Part 5 - Railways - Encoding Standard"
+    }, 
+    "ogc-16-106r2": {
+        "authors": [
+            "Hans-Christoph Gruler"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=75123", 
+        "ogcNumber": "16-106r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-08-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC InfraGML 1.0: Part 6 \u2013 LandInfra Survey - Encoding Standard"
+    }, 
+    "ogc-16-107r2": {
+        "authors": [
+            "Paul Scarponcini"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=75929", 
+        "ogcNumber": "16-107r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-09-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC InfraGML 1.0: Part 7 \u2013 LandInfra Land Division - Encoding Standard"
+    }, 
+    "ogc-16-114r2": {
+        "authors": [
+            "Martin Desruisseaux"
+        ], 
+        "href": "http://docs.opengeospatial.org/dp/16-114r2/16-114r2.html", 
+        "ogcNumber": "16-114r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-04-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Moving Features Encoding Extension: netCDF"
+    }, 
+    "ogc-16-114r3": {
+        "authors": [
+            "Martin Desruisseaux"
+        ], 
+        "href": "http://docs.opengeospatial.org/bp/16-114r3/16-114r3.html", 
+        "ogcNumber": "16-114r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-12-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Moving Features Encoding Extension: netCDF"
+    }, 
+    "ogc-16-115": {
+        "authors": [
+            "Guy Schumann"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-115.html", 
+        "ogcNumber": "16-115", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-10-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Future City Pilot 1 - Recommendations on Serving IFC via WFS"
+    }, 
+    "ogc-16-120r3": {
+        "authors": [
+            "Hideki Hayashi", 
+            "Akinori Asahara", 
+            "Kyoung-Sook Kim", 
+            "Ryosuke Shibasaki", 
+            "Nobuhiro Ishimaru"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/16-120r3/16-120r3.html", 
+        "ogcNumber": "16-120r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-03-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Moving Features Access"
+    }, 
+    "ogc-16-121r2": {
+        "authors": [
+            "Peter Baumann"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=72295", 
+        "ogcNumber": "16-121r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2016-12-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Web Query Service "
+    }, 
+    "ogc-16-129": {
+        "authors": [
+            "Ingo Simonis", 
+            "Rob Atkinson"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=70328", 
+        "ogcNumber": "16-129", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-03-31", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Standardized Information Models to Optimize Exchange, Reusability and Comparability of Citizen Science Data (SWE4CS)"
+    }, 
+    "ogc-16-131r2": {
+        "authors": [
+            "George Percivall"
+        ], 
+        "href": "http://docs.opengeospatial.org/wp/16-131r2/16-131r2.html", 
+        "ogcNumber": "16-131r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-09-25", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Big Geospatial Data \u2013 an OGC White Paper"
+    }, 
+    "ogc-16-137r2": {
+        "authors": [
+            "Lorenzo Bigagli"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/16-137r2.html", 
+        "ogcNumber": "16-137r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-05-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Testbed-12 PubSub / Catalog Engineering Report"
+    }, 
+    "ogc-16-140r1": {
+        "authors": [
+            "Kyoung-Sook KIM", 
+            "Hirotaka OGAWA"
+        ], 
+        "href": "http://docs.opengeospatial.org/bp/16-140r1/16-140r1.html", 
+        "ogcNumber": "16-140r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-06-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Moving Features Encoding Extension - JSON"
+    }, 
+    "ogc-17-002r1": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "http://docs.opengeospatial.org/cs/17-002r1/17-002r1.html", 
+        "ogcNumber": "17-002r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-08-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC GeoRSS Encoding Standard"
+    }, 
+    "ogc-17-007r1": {
+        "authors": [
+            "Andreas Matheus"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/17-007r1/17-007r1.html", 
+        "ogcNumber": "17-007r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-01-28", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Web Services Security"
+    }, 
+    "ogc-17-011r2": {
+        "authors": [
+            "Alex Robin"
+        ], 
+        "href": "http://docs.opengeospatial.org/bp/17-011r2/17-011r2.html", 
+        "ogcNumber": "17-011r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "JSON Encoding Rules SWE Common / SensorML"
+    }, 
+    "ogc-17-014r5": {
+        "authors": [
+            "Carl Reed", 
+            "Tamrat Belayneh"
+        ], 
+        "href": "http://docs.opengeospatial.org/cs/17-014r5/17-014r5.html", 
+        "ogcNumber": "17-014r5", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-09-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Indexed 3d Scene Layer (I3S) and Scene Layer Package Format Specification"
+    }, 
+    "ogc-17-018": {
+        "authors": [
+            "Alaitz Zabala", 
+            "Joan Maso"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-018.html", 
+        "ogcNumber": "17-018", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: Data Quality Specification Engineering Report"
+    }, 
+    "ogc-17-019": {
+        "authors": [
+            "Joan Maso"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-019.html", 
+        "ogcNumber": "17-019", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: MapML Engineering Report"
+    }, 
+    "ogc-17-020r1": {
+        "authors": [
+            "Johannes Echterhoff", 
+            "Clemens Portele"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-020r1.html", 
+        "ogcNumber": "17-020r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: NAS Profiling Engineering Report"
+    }, 
+    "ogc-17-021": {
+        "authors": [
+            "Andreas Matheus"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-021.html", 
+        "ogcNumber": "17-021", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: Security Engineering Report"
+    }, 
+    "ogc-17-022": {
+        "authors": [
+            "Guy Schumann"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-022.html", 
+        "ogcNumber": "17-022", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: NA001 Climate Data Accessibility for Adaptation Planning"
+    }, 
+    "ogc-17-023": {
+        "authors": [
+            "Pedro Gon\u00e7alves"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-023.html", 
+        "ogcNumber": "17-023", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: EP Application Package Engineering Report"
+    }, 
+    "ogc-17-024": {
+        "authors": [
+            "Pedro Gonc\u0327alves"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-024.html", 
+        "ogcNumber": "17-024", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: Application Deployment and Execution Service Engineering Report"
+    }, 
+    "ogc-17-025r2": {
+        "authors": [
+            "Aleksandar Balaban"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-025r2.html", 
+        "ogcNumber": "17-025r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-03-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: Quality Assessment Service Engineering Report"
+    }, 
+    "ogc-17-026r1": {
+        "authors": [
+            "Rob Cass"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-026r1.html", 
+        "ogcNumber": "17-026r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-02-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: Disconnected Networks Engineering Report"
+    }, 
+    "ogc-17-027": {
+        "authors": [
+            "Robert Cass"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-027.html", 
+        "ogcNumber": "17-027", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: GeoPackage Engineering Report"
+    }, 
+    "ogc-17-028": {
+        "authors": [
+            "Benjamin Pross", 
+            "Christoph Stasch"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-028.html", 
+        "ogcNumber": "17-028", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: Asynchronous Services ER"
+    }, 
+    "ogc-17-029r1": {
+        "authors": [
+            "Benjamin Pross", 
+            "Christoph Stasch"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-029r1.html", 
+        "ogcNumber": "17-029r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: Workflows ER"
+    }, 
+    "ogc-17-030r1": {
+        "authors": [
+            "ASPRS"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=74523", 
+        "ogcNumber": "17-030r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-03-01", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "LAS Specification 1.4 OGC Community Standard"
+    }, 
+    "ogc-17-032r2": {
+        "authors": [
+            "Anneley McMillan", 
+            "Sam Meek"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-032r2.html", 
+        "ogcNumber": "17-032r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: Aviation Abstract Quality Model Engineering Report"
+    }, 
+    "ogc-17-035": {
+        "authors": [
+            "Charles Chen"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-035.html", 
+        "ogcNumber": "17-035", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: Cloud ER"
+    }, 
+    "ogc-17-036": {
+        "authors": [
+            "Charles Chen"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-036.html", 
+        "ogcNumber": "17-036", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: Geospatial Taxonomies Engineering Report"
+    }, 
+    "ogc-17-037": {
+        "authors": [
+            "Jeff Harrison"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-037.html", 
+        "ogcNumber": "17-037", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-01", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: SWAP Engineering Report"
+    }, 
+    "ogc-17-038": {
+        "authors": [
+            "Jeff Harrison"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-038.html", 
+        "ogcNumber": "17-038", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: Fit-for-Purpose Engineering Report"
+    }, 
+    "ogc-17-040": {
+        "authors": [
+            "Stephen McCann", 
+            "Roger Brackin", 
+            "Gobe Hobona"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-040.html", 
+        "ogcNumber": "17-040", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: DCAT/SRIM Engineering Report"
+    }, 
+    "ogc-17-041": {
+        "authors": [
+            "Stefano Cavazzi"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-041.html", 
+        "ogcNumber": "17-041", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-02-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: Vector Tiles Engineering Report"
+    }, 
+    "ogc-17-042": {
+        "authors": [
+            "Sara Saeedi"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-042.html", 
+        "ogcNumber": "17-042", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: CDB Engineering Report"
+    }, 
+    "ogc-17-043": {
+        "authors": [
+            "Nuno Oliveira"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-043.html", 
+        "ogcNumber": "17-043", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: Executable Test Suites and Reference Implementations for NSG WMTS 1.0 and WFS 2.0 Profiles with Extension"
+    }, 
+    "ogc-17-045": {
+        "authors": [
+            "Stephane Fellah"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-045.html", 
+        "ogcNumber": "17-045", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-03-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: Portrayal Engineering Report"
+    }, 
+    "ogc-17-046": {
+        "authors": [
+            "Volker Coors"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-046.html", 
+        "ogcNumber": "17-046", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-03-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: 3D Tiles and I3S Interoperability and Performance Engineering Report"
+    }, 
+    "ogc-17-048": {
+        "authors": [
+            "Josh Lieberman", 
+            "Andy Ryan"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-048.html", 
+        "ogcNumber": "17-048", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-08-31", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Underground Infrastructure Concept Study Engineering Report"
+    }, 
+    "ogc-17-049": {
+        "authors": [
+            "C. Mitchell", 
+            "M. Gordon", 
+            "T. Kralidis"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=77148", 
+        "ogcNumber": "17-049", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-03-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Ensuring Quality of User Experience with OGC Web Mapping Services - Discussion Paper"
+    }, 
+    "ogc-17-059": {
+        "authors": [
+            "Lars Schylberg", 
+            "Lubos Belka"
+        ], 
+        "href": "http://docs.opengeospatial.org/dp/17-059/17-059.html", 
+        "ogcNumber": "17-059", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2017-10-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Technical report from the DGIWG Portrayal Technical Panel testing of SLD (1.1.0) for OGC"
+    }, 
+    "ogc-17-066r1": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/17-066r1/17-066r1.html", 
+        "ogcNumber": "17-066r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-03-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC GeoPackage Extension for Tiled Gridded Coverage Data"
+    }, 
+    "ogc-17-078": {
+        "authors": [
+            "Jeff Harrison"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-078.html", 
+        "ogcNumber": "17-078", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-01-17", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-13: Concepts of Data and Standards for Mass Migration Engineering Report"
+    }, 
+    "ogc-17-079r1": {
+        "authors": [
+            "Steve Liang", 
+            "Tania Khalafbeigi"
+        ], 
+        "href": "https://docs.opengeospatial.org/is/17-079r1/17-079r1.html", 
+        "ogcNumber": "17-079r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-01-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC SensorThings API Part 2 \u2013 Tasking Core"
+    }, 
+    "ogc-17-080r2": {
+        "authors": [
+            "Ryan Franz"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/17-080r2/17-080r2.html", 
+        "ogcNumber": "17-080r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-09-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "CDB Multi-Spectral Imagery Extension"
+    }, 
+    "ogc-17-088r1": {
+        "authors": [
+            "Luis Bermudez"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-088r1.html", 
+        "ogcNumber": "17-088r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-02-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Strengthening Disaster Risk Reduction Across the Americas Summit - Simulated Exercise Engineering Report"
+    }, 
+    "ogc-17-089r1": {
+        "authors": [
+            "Peter Baumann"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/17-089r1/17-089r1.html", 
+        "ogcNumber": "17-089r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-08-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Web Coverage Service (WCS) 2.1 Interface Standard - Core"
+    }, 
+    "ogc-17-093r1": {
+        "authors": [
+            "Jeff Yutzler", 
+            "Ashley Antonides"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-093r1.html", 
+        "ogcNumber": "17-093r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-08-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC GeoPackage Related Tables Extension Interoperability Experiment Engineering Report"
+    }, 
+    "ogc-17-094r1": {
+        "authors": [
+            "Jeff Yutzler", 
+            "Rob Cass"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/17-094r1.html", 
+        "ogcNumber": "17-094r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-10-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Portrayal Concept Development Study"
+    }, 
+    "ogc-18-001r1": {
+        "authors": [
+            "Lieven Raes", 
+            "Danny Vandenbroucke", 
+            "Tomas Reznik"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=82475", 
+        "ogcNumber": "18-001r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-01-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GeoDCAT-AP"
+    }, 
+    "ogc-18-004r1": {
+        "authors": [
+            "George Percivall"
+        ], 
+        "href": "http://docs.opengeospatial.org/wp/18-004r1/18-004r1.html", 
+        "ogcNumber": "18-004r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-07-31", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "The Role of Geospatial in Edge-Fog-Cloud Computing - An OGC White Paper"
+    }, 
+    "ogc-18-005r4": {
+        "authors": [
+            "Roger Lott"
+        ], 
+        "href": "http://docs.opengeospatial.org/as/18-005r4/18-005r4.html", 
+        "ogcNumber": "18-005r4", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 2: Referencing by coordinates"
+    }, 
+    "ogc-18-0077r2": {
+        "authors": [
+            "Jay Freeman", 
+            "Kevin Bentley", 
+            "Ronald Moore", 
+            "Samuel Chambers", 
+            "Glen Quesenberry"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=82553", 
+        "ogcNumber": "18-0077r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-01-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC CDB, Leveraging GeoPackage Discussion Paper"
+    }, 
+    "ogc-18-008r1": {
+        "authors": [
+            "Christiaan Lemmen", 
+            "Peter van Oosterom", 
+            "Mohsen Kalantari", 
+            "Eva-Maria Unger", 
+            "Cornelis de Zeeuw"
+        ], 
+        "href": "http://docs.opengeospatial.org/wp/18-008r1/18-008r1.html", 
+        "ogcNumber": "18-008r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC White Paper on Land Administration"
+    }, 
+    "ogc-18-016r1": {
+        "authors": [
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/16-018r1", 
+        "ogcNumber": "18-016r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-12-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC CDB Version 1.1 Release Notes"
+    }, 
+    "ogc-18-021": {
+        "authors": [
+            "Clemens Portele"
+        ], 
+        "href": "https://docs.opengeospatial.org/per/18-021.html", 
+        "ogcNumber": "18-021", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-03-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14 Next Generation APIs: Complex Feature Handling Engineering Report"
+    }, 
+    "ogc-18-022r1": {
+        "authors": [
+            "Yann Le Franc"
+        ], 
+        "href": "https://docs.opengeospatial.org/per/18-022r1.html", 
+        "ogcNumber": "18-022r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: SWIM Information Registry Engineering Report"
+    }, 
+    "ogc-18-023r1": {
+        "authors": [
+            "Joan Mas\u00f3"
+        ], 
+        "href": "https://docs.opengeospatial.org/per/18-023r1.html", 
+        "ogcNumber": "18-023r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-03-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: MapML Engineering Report"
+    }, 
+    "ogc-18-024r1": {
+        "authors": [
+            "Jeff Yutzler"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/18-024r1", 
+        "ogcNumber": "18-024r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-12-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Release Notes for OGC GeoPackage Encoding Standard v1.2.1"
+    }, 
+    "ogc-18-025": {
+        "authors": [
+            "J\u00e9r\u00f4me Jacovella-St-Louis"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/18-025.html", 
+        "ogcNumber": "18-025", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-03-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: CityGML and AR Engineering Report"
+    }, 
+    "ogc-18-026r1": {
+        "authors": [
+            "Juan Jos\u00e9 Doval", 
+            "H\u00e9ctor Rodr\u00edguez"
+        ], 
+        "href": "https://docs.opengeospatial.org/per/18-026r1.html", 
+        "ogcNumber": "18-026r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-03-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: Security Engineering Report"
+    }, 
+    "ogc-18-028r2": {
+        "authors": [
+            "Guy Schumann"
+        ], 
+        "href": "https://docs.opengeospatial.org/per/18-028r2.html", 
+        "ogcNumber": "18-028r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: WMS QoSE Engineering Report"
+    }, 
+    "ogc-18-029": {
+        "authors": [
+            "Sara Saeedi"
+        ], 
+        "href": "https://docs.opengeospatial.org/per/18-029.html", 
+        "ogcNumber": "18-029", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-03-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: Symbology Engineering Report"
+    }, 
+    "ogc-18-030": {
+        "authors": [
+            "Sara Saeedi"
+        ], 
+        "href": "https://docs.opengeospatial.org/per/18-030.html", 
+        "ogcNumber": "18-030", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-03-06", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: Secure Client Test Engineering Report"
+    }, 
+    "ogc-18-032r2": {
+        "authors": [
+            "Johannes Echterhoff"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/18-032r2.html", 
+        "ogcNumber": "18-032r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: Application Schema-based Ontology Development Engineering Report"
+    }, 
+    "ogc-18-034r3": {
+        "authors": [
+            "Andrea Aime", 
+            "Emanuele Tajariol", 
+            "Simone Giannecchini"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/18-034r3.html", 
+        "ogcNumber": "18-034r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: Compliance Engineering Report"
+    }, 
+    "ogc-18-035": {
+        "authors": [
+            "Stephane Fellah"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/18-035.html", 
+        "ogcNumber": "18-035", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: Semantically Enabled Aviation Data Models Engineering Report"
+    }, 
+    "ogc-18-036r1": {
+        "authors": [
+            "Benjamin Pross", 
+            "Arnaud Cauchy"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/18-036r1.html", 
+        "ogcNumber": "18-036r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: WPS-T Engineering Report"
+    }, 
+    "ogc-18-037r1": {
+        "authors": [
+            "Jeff Yutzler"
+        ], 
+        "href": "http://docs.opengeospatial.org/dp/18-037r1/18-037r1.html", 
+        "ogcNumber": "18-037r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-10-29", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "GeoPackage / OWS Context Harmonization Discussion Paper"
+    }, 
+    "ogc-18-038r2": {
+        "authors": [
+            "Tom Landry"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/18-038r2.html", 
+        "ogcNumber": "18-038r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: Machine Learning Engineering Report"
+    }, 
+    "ogc-18-041r1": {
+        "authors": [
+            "Gobe Hobona", 
+            "Bart De Lathouwer"
+        ], 
+        "href": "http://docs.opengeospatial.org/dp/18-041r1/18-041r1.html", 
+        "ogcNumber": "18-041r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-10-09", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Geospatial Standardization of Distributed Ledger Technologies"
+    }, 
+    "ogc-18-045": {
+        "authors": [
+            "Jeff Harrison", 
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "https://docs.opengeospatial.org/per/18-045.html", 
+        "ogcNumber": "18-045", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-03-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: Next Generation Web APIs - WFS 3.0 Engineering Report"
+    }, 
+    "ogc-18-046": {
+        "authors": [
+            "Ingo Simonis"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/18-046.html", 
+        "ogcNumber": "18-046", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-12-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Earth Observation Exploitation Platform Hackathon 2018 Engineering Report"
+    }, 
+    "ogc-18-047r3": {
+        "authors": [
+            "Eugene Genong Yu", 
+            "Liping Di"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/18-047r3.html", 
+        "ogcNumber": "18-047r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: Swath Coverage Engineering Report"
+    }, 
+    "ogc-18-048r1": {
+        "authors": [
+            "Howard Butler"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/18-048r1.html", 
+        "ogcNumber": "18-048r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-03-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: Point Cloud Data Handling Engineering Report"
+    }, 
+    "ogc-18-049r1": {
+        "authors": [
+            "Paulo Sacramento"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/18-049r1.html", 
+        "ogcNumber": "18-049r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: Application Package Engineering Report"
+    }, 
+    "ogc-18-050r1": {
+        "authors": [
+            "Paulo Sacramento"
+        ], 
+        "href": "https://docs.opengeospatial.org/per/18-050r1.html", 
+        "ogcNumber": "18-050r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-08", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: ADES & EMS Results and Best Practices Engineering Report"
+    }, 
+    "ogc-18-053r2": {
+        "authors": [
+            "Patrick Cozzi", 
+            "Sean Lilley", 
+            "Gabby Getz"
+        ], 
+        "href": "http://docs.opengeospatial.org/cs/18-053r2/18-053r2.html", 
+        "ogcNumber": "18-053r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-01-31", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC 3D Tiles Specification 1.0"
+    }, 
+    "ogc-18-056": {
+        "authors": [
+            "Steve Liang", 
+            "Tania Khalafbeigi", 
+            "Kan Luo"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=79179", 
+        "ogcNumber": "18-056", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-12-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC SensorThings API Tasking Core Discussion Paper"
+    }, 
+    "ogc-18-057": {
+        "authors": [
+            "J\u00e9r\u00f4me Gasperi"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/18-057.html", 
+        "ogcNumber": "18-057", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: Authorisation, Authentication, & Billing Engineering Report"
+    }, 
+    "ogc-18-074": {
+        "authors": [
+            "Jeff Yutzler"
+        ], 
+        "href": "https://docs.opengeospatial.org/per/18-074.html", 
+        "ogcNumber": "18-074", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Vector Tiles Pilot: GeoPackage 1.2 Vector Tiles Extensions Engineering Report"
+    }, 
+    "ogc-18-075": {
+        "authors": [
+            "Akinori Asahara", 
+            "Ryosuke Shibasaki", 
+            "Nobuhiro Ishimaru", 
+            "David Burggraf"
+        ], 
+        "href": "http://docs.opengeospatial.org/is/18-075/18-075.html", 
+        "ogcNumber": "18-075", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-01-14", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC\u00ae Moving Features Encoding Part I: XML Core"
+    }, 
+    "ogc-18-076": {
+        "authors": [
+            "Jens Ingensand", 
+            "Kalimar Maia"
+        ], 
+        "href": "https://docs.opengeospatial.org/per/18-076.html", 
+        "ogcNumber": "18-076", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Vector Tiles Pilot: Tiled Feature Data Conceptual Model Engineering Report"
+    }, 
+    "ogc-18-078": {
+        "authors": [
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "https://docs.opengeospatial.org/per/18-078.html", 
+        "ogcNumber": "18-078", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Vector Tiles Pilot: WFS 3.0 Vector Tiles Extension Engineering Report"
+    }, 
+    "ogc-18-083": {
+        "authors": [
+            "Panagiotis (Peter) A. Vretanos"
+        ], 
+        "href": "https://docs.opengeospatial.org/per/18-083.html", 
+        "ogcNumber": "18-083", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Vector Tiles Pilot: WMTS Vector Tiles Extension Engineering Report"
+    }, 
+    "ogc-18-084": {
+        "authors": [
+            "Luis Bermudez"
+        ], 
+        "href": "https://docs.opengeospatial.org/per/18-084.html", 
+        "ogcNumber": "18-084", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-01-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Geospatial to the Edge Plugfest Engineering Report"
+    }, 
+    "ogc-18-085": {
+        "authors": [
+            "Sam Meek"
+        ], 
+        "href": "https://docs.opengeospatial.org/per/18-085.html", 
+        "ogcNumber": "18-085", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: BPMN Workflow Engineering Report"
+    }, 
+    "ogc-18-086r1": {
+        "authors": [
+            "Sam Meek"
+        ], 
+        "href": "https://docs.opengeospatial.org/per/18-086r1.html", 
+        "ogcNumber": "18-086r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-15", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Vector Tiles Pilot: Summary Engineering Report"
+    }, 
+    "ogc-18-087r5": {
+        "authors": [
+            "Terry Idol", 
+            "Robert Thomas"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/18-087r5", 
+        "ogcNumber": "18-087r5", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2018-12-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Development of Disaster Spatial Data Infrastructures for Disaster Resilience"
+    }, 
+    "ogc-18-090r1": {
+        "authors": [
+            "Dr. Craig A. Lee"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/18-090r1.html", 
+        "ogcNumber": "18-090r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-03-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: Federated Clouds Engineering Report"
+    }, 
+    "ogc-18-091r2": {
+        "authors": [
+            "Johannes Echterhoff"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/18-091r2.html", 
+        "ogcNumber": "18-091r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: Application Schemas and JSON Technologies Engineering Report"
+    }, 
+    "ogc-18-094r1": {
+        "authors": [
+            "Stephane Fellah"
+        ], 
+        "href": "http://docs.opengeospatial.org/per/18-094r1.html", 
+        "ogcNumber": "18-094r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Testbed-14: Characterization of RDF Application Profiles for Simple Linked Data Application and Complex Analytic Applicat"
+    }, 
+    "ogc-18-097": {
+        "authors": [
+            "David Blodgett", 
+            "Byron Cochrane", 
+            "Rob Atkinson", 
+            "Sylvain Grellet", 
+            "Abdelfettah Feliachi", 
+            "Alistair Ritchi"
+        ], 
+        "href": "https://docs.opengeospatial.org/per/18-097.html", 
+        "ogcNumber": "18-097", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2019-02-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Environmental Linked Features Interoperability Experiment Engineering Report"
+    }, 
+    "ogc-99-049": {
+        "authors": [
+            "Keith Ryden"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=829", 
+        "ogcNumber": "99-049", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "1999-05-05", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Simple Features Implementation Specification for SQL"
+    }, 
+    "ogc-99-050": {
+        "authors": [
+            "TC Chair"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=830", 
+        "ogcNumber": "99-050", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "1999-05-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Simple Features Implementation Specification for OLE/COM"
+    }, 
+    "ogc-99-051": {
+        "authors": [
+            "Doug Nebert"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=831", 
+        "ogcNumber": "99-051", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "1999-07-16", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Catalog Interface"
+    }, 
+    "ogc-99-054": {
+        "authors": [
+            "Peter Ladstaetter"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=834", 
+        "ogcNumber": "99-054", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "1999-06-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OpenGIS Simple Features Implementation Specification for CORBA"
+    }, 
+    "ogc-99-103": {
+        "authors": [
+            "Cliff Kottman"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=886", 
+        "ogcNumber": "99-103", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "1999-03-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 3 - Locational Geometry Structures"
+    }, 
+    "ogc-99-104": {
+        "authors": [
+            "Cliff Kottman"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=887", 
+        "ogcNumber": "99-104", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "1999-03-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 4 - Stored Functions and Interpolation"
+    }, 
+    "ogc-99-105r2": {
+        "authors": [
+            "Cliff Kottman"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=890", 
+        "ogcNumber": "99-105r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "1999-03-24", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 5 - Features"
+    }, 
+    "ogc-99-107": {
+        "authors": [
+            "Cliff Kottman"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=892", 
+        "ogcNumber": "99-107", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "1999-03-31", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 7 - Earth Imagery"
+    }, 
+    "ogc-99-108r2": {
+        "authors": [
+            "Cliff Kottman"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=894", 
+        "ogcNumber": "99-108r2", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "1999-03-26", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 8 - Relationships Between Features"
+    }, 
+    "ogc-99-109r1": {
+        "authors": [
+            "Cliff Kottman", 
+            "Arliss Whiteside"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=896", 
+        "ogcNumber": "99-109r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "1999-03-30", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 9 - Accuracy"
+    }, 
+    "ogc-99-110": {
+        "authors": [
+            "Cliff Kottman"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=897", 
+        "ogcNumber": "99-110", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "1999-04-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 10 - Feature Collections"
+    }, 
+    "ogc-99-113": {
+        "authors": [
+            "Cliff Kottman"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=901", 
+        "ogcNumber": "99-113", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "1999-03-31", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 13 - Catalog Services"
+    }, 
+    "ogc-99-114": {
+        "authors": [
+            "Cliff Kottman"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=902", 
+        "ogcNumber": "99-114", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "1999-04-04", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Topic 14 - Semantics and Information Communities"
+    }, 
+    "ogc-OGC 07-165r1": {
+        "authors": [
+            "Mike Botts", 
+            "George Percivall", 
+            "Carl Reed", 
+            "John Davidson"
+        ], 
+        "href": "http://docs.opengeospatial.org/wp/07-165r1/", 
+        "ogcNumber": "OGC 07-165r1", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2013-04-02", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Sensor Web Enablement: Overview and High Level Architecture"
+    }, 
+    "ogc-OGC 09-044r3": {
+        "authors": [
+            "George Percivall", 
+            "Raj Singh"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=49321", 
+        "ogcNumber": "OGC 09-044r3", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-07-12", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Geospatial Business Intelligence (GeoBI)"
+    }, 
+    "ogc-OGC 10-128": {
+        "authors": [
+            "Luis Bermudez"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=41359", 
+        "ogcNumber": "OGC 10-128", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2010-10-22", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Compliance Testing White Paper"
+    }, 
+    "ogc-OGC 11-036": {
+        "authors": [
+            "Lance McKee", 
+            "Carl Reed", 
+            "Steven Ramage"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=43743", 
+        "ogcNumber": "OGC 11-036", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-04-07", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "OGC Standards and Cloud Computing"
+    }, 
+    "ogc-OGC 11-110": {
+        "authors": [
+            "Arnulf Christl", 
+            "Carl Reed"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=45126", 
+        "ogcNumber": "OGC 11-110", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-08-11", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Open Source and Open Standards"
+    }, 
+    "ogc-OGC 11-145": {
+        "authors": [
+            "George Percivall"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46388", 
+        "ogcNumber": "OGC 11-145", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2014-05-20", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Cyberarchitecture for Geosciences   White Paper"
+    }, 
+    "ogc-OGC 11-159": {
+        "authors": [
+            "David Maidment", 
+            "Ben Domenico", 
+            "Alastair Gemmell", 
+            "Kerstin Lehnert", 
+            "David Tarboton", 
+            "Ilya Zaslavsky"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=46471&version=1", 
+        "ogcNumber": "OGC 11-159", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2011-10-19", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "The Open Geospatial Consortium and EarthCube"
+    }, 
+    "ogc-OGC 12-026": {
+        "authors": [
+            "Andreas Matheus"
+        ], 
+        "href": "https://portal.opengeospatial.org/files/?artifact_id=47848", 
+        "ogcNumber": "OGC 12-026", 
+        "publisher": "Open Geospatial Consortium", 
+        "rawDate": "2012-04-18", 
+        "source": "http://www.opengeospatial.org", 
+        "title": "Architecture of an Access Management Federation for Spatial Data and Services in Germany"
+    }
+}


### PR DESCRIPTION
This Pull Request adds the complete catalogue of specifications of the Open Geospatial Consortium (OGC). The catalogue includes OGC standards, extensions, profiles, best practices, engineering reports, discussion papers, and other specifications.