### PR TITLE
Adobe RGB (1998) colorspace

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -52,6 +52,12 @@
         "etAl": true,
         "date": "July 2009"
     },
+    "AdobeRGB": {
+        "href": "https://www.adobe.com/digitalimag/pdfs/AdobeRGB1998.pdf",
+        "title": "Adobe®RGB(1998) Color Image Encoding",
+        "publisher": "Adobe Systems Incorporated",
+        "date": "May 2005"
+    }
     "AES": {
         "href": "https://csrc.nist.gov/publications/fips/fips197/fips-197.pdf",
         "title": "NIST FIPS 197: Advanced Encryption Standard (AES)",

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -57,7 +57,7 @@
         "title": "Adobe®RGB(1998) Color Image Encoding",
         "publisher": "Adobe Systems Incorporated",
         "date": "May 2005"
-    }
+    },
     "AES": {
         "href": "https://csrc.nist.gov/publications/fips/fips197/fips-197.pdf",
         "title": "NIST FIPS 197: Advanced Encryption Standard (AES)",


### PR DESCRIPTION
This is the widely used Adobe colorspace, popular as a somewhat wide color gamut color encoding in digital photography. The name is a registered trademark, and using the actual ICC profile requires a written license agreement, but referencing the specification can be done without any license.