### PR TITLE
Move media drafts transferred from WICG to W3C Media WG

### DIFF
--- a/refs/w3c.json
+++ b/refs/w3c.json
@@ -44719,6 +44719,19 @@
         "rawDate": "2010-01-21",
         "source": "https://www.w3.org/2002/01/tr-automation/tr.rdf"
     },
+    "media-capabilities": {
+        "authors": [
+            "Mounir Lamouri"
+        ],
+        "href": "https://w3c.github.io/media-capabilities/",
+        "title": "Media Capabilities",
+        "status": "ED",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/media-wg/"
+        ],
+        "repository": "https://github.com/w3c/media-capabilities"
+    },
     "media-capture-api": {
         "authors": [
             "Dzung Tran",
@@ -44908,6 +44921,19 @@
         },
         "rawDate": "2009-12-17",
         "source": "https://www.w3.org/2002/01/tr-automation/tr.rdf"
+    },
+    "media-playback-quality": {
+        "authors": [
+            "Mounir Lamouri"
+        ],
+        "href": "https://w3c.github.io/media-playback-quality/",
+        "title": "Media Playback Quality",
+        "status": "ED",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/media-wg/"
+        ],
+        "repository": "https://github.com/w3c/media-playback-quality"
     },
     "media-source": {
         "authors": [
@@ -45945,6 +45971,21 @@
         },
         "edDraft": "https://drafts.csswg.org/mediaqueries-4/",
         "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "mediasession": {
+        "authors": [
+            "Mounir Lamouri",
+            "Zhiqiang Zhang",
+            "Rich Tibbett"
+        ],
+        "href": "https://w3c.github.io/mediasession/",
+        "title": "Media Session",
+        "status": "ED",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/media-wg/"
+        ],
+        "repository": "https://github.com/w3c/mediasession"
     },
     "mediastream-recording": {
         "authors": [
@@ -55493,6 +55534,20 @@
         "status": "NOTE",
         "rawDate": "1997-05-14",
         "title": "PICS-NG Metadata Model and Label Syntax"
+    },
+    "picture-in-picture": {
+        "authors": [
+            "François Beaufort",
+            "Mounir Lamouri"
+        ],
+        "href": "https://w3c.github.io/picture-in-picture/",
+        "title": "Picture-in-Picture",
+        "status": "ED",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/media-wg/"
+        ],
+        "repository": "https://github.com/w3c/picture-in-picture"
     },
     "png-hdr-pq": {
         "authors": [

--- a/refs/wicg.json
+++ b/refs/wicg.json
@@ -159,30 +159,6 @@
         "source": "https://wicg.github.io/admin/biblio.json",
         "repository": "https://github.com/wicg/layout-instability"
     },
-    "MEDIA-CAPABILITIES": {
-        "href": "https://wicg.github.io/media-capabilities/",
-        "title": "Media Capabilities",
-        "status": "cg-draft",
-        "publisher": "WICG",
-        "source": "https://wicg.github.io/admin/biblio.json",
-        "repository": "https://github.com/wicg/media-capabilities"
-    },
-    "MEDIA-PLAYBACK-QUALITY": {
-        "href": "https://wicg.github.io/media-playback-quality/",
-        "title": "Media Playback Quality",
-        "status": "cg-draft",
-        "publisher": "WICG",
-        "source": "https://wicg.github.io/admin/biblio.json",
-        "repository": "https://github.com/wicg/media-playback-quality"
-    },
-    "MEDIASESSION": {
-        "href": "https://wicg.github.io/mediasession/",
-        "title": "Media Session",
-        "status": "cg-draft",
-        "publisher": "WICG",
-        "source": "https://wicg.github.io/admin/biblio.json",
-        "repository": "https://github.com/wicg/mediasession"
-    },
     "NATIVE-FILE-SYSTEM": {
         "href": "https://wicg.github.io/native-file-system/",
         "title": "Native File System",
@@ -230,14 +206,6 @@
         "publisher": "WICG",
         "source": "https://wicg.github.io/admin/biblio.json",
         "repository": "https://github.com/wicg/permissions-revoke"
-    },
-    "PICTURE-IN-PICTURE": {
-        "href": "https://wicg.github.io/picture-in-picture/",
-        "title": "Picture-in-Picture",
-        "status": "cg-draft",
-        "publisher": "WICG",
-        "source": "https://wicg.github.io/admin/biblio.json",
-        "repository": "https://github.com/wicg/picture-in-picture"
     },
     "PRIORITY-HINTS": {
         "href": "https://wicg.github.io/priority-hints/",


### PR DESCRIPTION
Specs on their way to being removed from WICG's `biblio.json`:
https://github.com/WICG/admin/pull/76
