### PR TITLE
updated bibo domain

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -3261,7 +3261,7 @@
             "Bruce D'Arcus",
             "Frédérick Giasson"
         ],
-        "href": "http://bibliographic-ontology.org/specification",
+        "href": "http://bibliontology.com/specification.html",
         "title": "Bibliographic Ontology Specification",
         "publisher": "Structured Dynamics LLC.",
         "rawDate": "2016-05-11"


### PR DESCRIPTION
bibliographic-ontology.com times out now. The domain appears to have changed to bibliontology.com.