### PR TITLE
Move REPORTING spec from WICG to W3C.

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2351,6 +2351,20 @@
         "date": "2008",
         "isoNumber": "ISO/IEC 19757-2:2008"
     },
+    "REPORTING": {
+        "authors": [
+            "Douglas Creager",
+            "Ian Clelland",
+            "Mike West",
+            "Ilya Grigorik",
+            "Paul Meyer"
+        ],
+        "href": "https://w3c.github.io/reporting/",
+        "publisher": "W3C",
+        "repository": "https://github.com/w3c/reporting",
+        "status": "ED",
+        "title": "Reporting API"
+    },
     "RFC-INDEX": {
         "href": "https://www.rfc-editor.org/rfc-index.html",
         "title": "RFC Index",

--- a/refs/wicg.json
+++ b/refs/wicg.json
@@ -215,14 +215,6 @@
         "source": "https://wicg.github.io/admin/biblio.json",
         "repository": "https://github.com/wicg/priority-hints"
     },
-    "REPORTING": {
-        "href": "https://wicg.github.io/reporting/",
-        "title": "Reporting API",
-        "status": "cg-draft",
-        "publisher": "WICG",
-        "source": "https://wicg.github.io/admin/biblio.json",
-        "repository": "https://github.com/wicg/reporting"
-    },
     "RESIZE-OBSERVER": {
         "href": "https://wicg.github.io/ResizeObserver/",
         "title": "Resize Observer",


### PR DESCRIPTION
Fixes: #574