### PR TITLE
fix: Convert `reporting` into alias of `reporting‑1`

### DIFF
--- a/refs/w3c.json
+++ b/refs/w3c.json
@@ -64873,6 +64873,9 @@
         },
         "repository": "https://github.com/w3c/remote-playback"
     },
+    "reporting": {
+        "aliasOf": "reporting-1"
+    },
     "reporting-1": {
         "authors": [
             "Douglas Creager",

--- a/refs/wicg.json
+++ b/refs/wicg.json
@@ -215,14 +215,6 @@
         "source": "https://wicg.github.io/admin/biblio.json",
         "repository": "https://github.com/wicg/priority-hints"
     },
-    "REPORTING": {
-        "href": "https://wicg.github.io/reporting/",
-        "title": "Reporting API",
-        "status": "cg-draft",
-        "publisher": "WICG",
-        "source": "https://wicg.github.io/admin/biblio.json",
-        "repository": "https://github.com/wicg/reporting"
-    },
     "RESIZE-OBSERVER": {
         "href": "https://wicg.github.io/ResizeObserver/",
         "title": "Resize Observer",


### PR DESCRIPTION
This already exists in `w3c.json` as `reporting‑1`.

---

Supersedes and closes #575
Fixes #574 