### PR TITLE
fix: Move `web‑share` to W3C

### DIFF
--- a/overwrites/wicg.json
+++ b/overwrites/wicg.json
@@ -1,0 +1,3 @@
+[
+    { "id": "WEB-SHARE", "action": "delete" }
+]

--- a/refs/w3c.json
+++ b/refs/w3c.json
@@ -83966,6 +83966,38 @@
         ],
         "isRetired": true
     },
+    "web-share": {
+        "authors": [
+            "Matt Giuca"
+        ],
+        "href": "https://www.w3.org/TR/web-share/",
+        "title": "Web Share API",
+        "rawDate": "2019-12-17",
+        "status": "WD",
+        "publisher": "W3C",
+        "edDraft": "https://w3c.github.io/web-share/",
+        "deliveredBy": [
+            "https://www.w3.org/2019/webapps/"
+        ],
+        "source": "https://www.w3.org/2002/01/tr-automation/tr.rdf",
+        "versions": {
+            "20191217": {
+                "authors": [
+                    "Matt Giuca"
+                ],
+                "href": "https://www.w3.org/TR/2019/WD-web-share-20191217/",
+                "title": "Web Share API",
+                "rawDate": "2019-12-17",
+                "status": "WD",
+                "publisher": "W3C",
+                "deliveredBy": [
+                    "https://www.w3.org/2019/webapps/"
+                ],
+                "source": "https://www.w3.org/2002/01/tr-automation/tr.rdf"
+            }
+        },
+        "repository": "https://github.com/w3c/web-share"
+    },
     "webarch": {
         "authors": [
             "Ian Jacobs",

--- a/refs/wicg.json
+++ b/refs/wicg.json
@@ -279,14 +279,6 @@
         "source": "https://wicg.github.io/admin/biblio.json",
         "repository": "https://github.com/wicg/web-locks"
     },
-    "WEB-SHARE": {
-        "href": "https://wicg.github.io/web-share/",
-        "title": "Web Share API",
-        "status": "cg-draft",
-        "publisher": "WICG",
-        "source": "https://wicg.github.io/admin/biblio.json",
-        "repository": "https://github.com/wicg/web-share"
-    },
     "WEB-SHARE-TARGET": {
         "href": "https://wicg.github.io/web-share-target/",
         "title": "Web Share Target API",


### PR DESCRIPTION
When&nbsp;I&nbsp;tried to&nbsp;run the&nbsp;update&nbsp;scripts&nbsp;locally, the&nbsp;tests&nbsp;failed because&nbsp;`web‑share` wasn’t&nbsp;automatically removed from&nbsp;`wicg.json`&nbsp;when it&nbsp;was&nbsp;added to&nbsp;`w3c.json`.

---

See&nbsp;also: <https://github.com/tobie/specref/issues/581>