### PR TITLE
Support aliasOf in importScripts

### DIFF
--- a/scripts/fetch-refs.js
+++ b/scripts/fetch-refs.js
@@ -35,9 +35,14 @@ request({
     var json = JSON.parse(body);
     Object.keys(json).forEach(function(id) {
         var ref = json[id];
-        ref = require(HELPER)(id, ref);
-        ref.publisher = ref.publisher || PUBLISHER;
-        ref.source = SOURCE;
+        if (ref.aliasOf) {
+            ref = { aliasOf: ref.aliasOf };
+        }
+        else {
+            ref = require(HELPER)(id, ref);
+            ref.publisher = ref.publisher || PUBLISHER;
+            ref.source = SOURCE;
+        }
         var uppercaseId = id.toUpperCase();
         var prefixedId = PUBLISHER + "-" + id;
         if (!(uppercaseId in refs)) {


### PR DESCRIPTION
The SCTE bibliography has started to use the `aliasOf` keyword. See #581.

The import script now stores an object with a single `aliasOf` property when it gets one in the list of specs it parses.

(The update does not trigger any change to other biblio files and makes tests green again).