### PR TITLE
Drop overwrite file for WICG

### DIFF
--- a/overwrites/wicg.json
+++ b/overwrites/wicg.json
@@ -1,3 +1,0 @@
-[
-    { "id": "WEB-SHARE", "action": "delete" }
-]


### PR DESCRIPTION
Web Share API has now been removed from biblio file on WICG side, and no longer triggers any conflict.