### PR TITLE
CIE Lab

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -354,6 +354,13 @@
             }
         }
     },
+    "CIELAB": {
+        "href": "http://cie.co.at/publications/colorimetry-part-4-cie-1976-lab-colour-space-1",
+        "title": "ISO/CIE 11664-4:2019(E): Colorimetry — Part 4: CIE 1976 L*a*b* colour space",
+        "publisher": "International Organization for Standardization (ISO), International Commission on Illumination (CIE)",
+        "status": "Published",
+        "date": "2019"
+    },
     "CLABS-HNAPI": {
         "href": "https://www.w3.org/2011/webtv/HNTF/CableLabs_Revised_API_20110727-2.pdf",
         "title": "CableLabs Revised Home Networking API",


### PR DESCRIPTION
Add most recent (2nd edition) joint ISO/CIE definition for CIE 1976 L*a*b*.

"colour"is not a typo; ISO standards use international English not US English