### PR TITLE
update MS Accessibility API refs to use permanent docs.microsoft.com links

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2043,8 +2043,8 @@
         "aliasOf": "iso23008-2"
     },
     "MSAA": {
-        "href": "https://msdn.microsoft.com/en-us/library/ms697707.aspx",
-        "title": "Microsoft Active Accessibility (MSAA) 2.0",
+        "href": "https://docs.microsoft.com/en-us/windows/win32/winauto/microsoft-active-accessibility",
+        "title": "Microsoft Active Accessibility (MSAA)",
         "publisher": "Microsoft Corporation"
     },
     "MSDN-SETCAPTURE": {
@@ -2828,7 +2828,7 @@
         "aliasOf": "typedarray"
     },
     "UI-AUTOMATION": {
-        "href": "https://msdn.microsoft.com/en-us/library/ee684009%28v=vs.85%29.aspx",
+        "href": "https://docs.microsoft.com/en-us/windows/win32/winauto/ui-automation-specification",
         "title": "UI Automation",
         "publisher": "Microsoft Corporation"
     },
@@ -2836,7 +2836,7 @@
         "aliasOf": "uievents"
     },
     "UIA-EXPRESS": {
-        "href": "https://msdn.microsoft.com/en-us/library/windows/desktop/dd561898%28v=vs.85%29.aspx",
+        "href": "https://docs.microsoft.com/en-us/windows/win32/winauto/iaccessibleex",
         "title": "The IAccessibleEx Interface",
         "publisher": "Microsoft Corporation"
     },


### PR DESCRIPTION
The old MSDN reference links were out of date.
This updates those references to use MS docs links.

I didn't open an issue for this, because the PR is self-explanatory.