### PR TITLE
Add reference to UFO

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2827,6 +2827,14 @@
     "TYPED-ARRAYS": {
         "aliasOf": "typedarray"
     },
+    "UFO": {
+        "authors": [
+            "G. Guizzardi"
+        ],
+        "href": "https://ris.utwente.nl/ws/portalfiles/portal/6042428/thesis_Guizzardi.pdf",
+        "title": "Ontological Foundations for Structural Conceptual Models",
+        "date": "2005"
+    },    
     "UI-AUTOMATION": {
         "href": "https://docs.microsoft.com/en-us/windows/win32/winauto/ui-automation-specification",
         "title": "UI Automation",


### PR DESCRIPTION
Added reference to the Ph.D. thesis of G. Guizzardi named "Ontological Foundations for Structural Conceptual Models" which describes the UFO ontology and the OntoUML language.