### PR TITLE
Update info for Trusted Types spec

### DIFF
--- a/overwrites/wicg.json
+++ b/overwrites/wicg.json
@@ -1,0 +1,3 @@
+[
+    { "id": "TRUSTED-TYPES", "action": "delete" }
+]

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2781,6 +2781,17 @@
         "publisher": "Apple, Inc.",
         "title": "TrueType™ Reference Manual"
     },
+    "TRUSTED-TYPES": {
+        "authors": [
+            "Krzysztof Kotowicz",
+            "Mike West"
+        ],
+        "href": "https://w3c.github.io/webappsec-trusted-types/dist/spec/",
+        "title": "Trusted Types",
+        "status": "ED",
+        "publisher": "W3C",
+        "repository": "https://github.com/w3c/webappsec-trusted-types/"
+    },
     "TSVWG-RTCWEB-QOS": {
         "authors": [
             "S. Dhesikan",

--- a/refs/wicg.json
+++ b/refs/wicg.json
@@ -255,14 +255,6 @@
         "source": "https://wicg.github.io/admin/biblio.json",
         "repository": "https://github.com/wicg/shape-detection-api"
     },
-    "TRUSTED-TYPES": {
-        "href": "https://wicg.github.io/trusted-types/dist/spec/",
-        "title": "Trusted Types Spec WIP",
-        "status": "cg-draft",
-        "publisher": "WICG",
-        "source": "https://wicg.github.io/admin/biblio.json",
-        "repository": "https://github.com/wicg/trusted-types"
-    },
     "VISUAL-VIEWPORT": {
         "href": "https://wicg.github.io/visual-viewport/",
         "title": "Visual Viewport API",


### PR DESCRIPTION
The spec moved to the Web Application Security Working Group and ED URL is no longer correct.

The need for the wicg.json overwrite is temporary while the entry gets removed from wicg/admin (I'll prepare a PR for that).