### PR TITLE
Updated entry INSPIRE-MD

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -3805,7 +3805,7 @@
         ],
         "versions": {
             "20081219": {
-                "href": "http://inspire.ec.europa.eu/reports/ImplementingRules/metadata/MD_IR_and_ISO_20081219.pdf",
+                "href": "https://inspire.ec.europa.eu/reports/ImplementingRules/metadata/MD_IR_and_ISO_20081219.pdf",
                 "title": "INSPIRE Metadata Implementing Rules: Technical Guidelines based on EN ISO 19115 and EN ISO 19119. Version 1.0",
                 "rawDate": "2008-12-19",
                 "publisher": "European Commission",
@@ -3814,7 +3814,7 @@
                 ]
             },
             "20090218": {
-                "href": "http://inspire.ec.europa.eu/reports/ImplementingRules/metadata/MD_IR_and_ISO_20090218.pdf",
+                "href": "https://inspire.ec.europa.eu/reports/ImplementingRules/metadata/MD_IR_and_ISO_20090218.pdf",
                 "title": "INSPIRE Metadata Implementing Rules: Technical Guidelines based on EN ISO 19115 and EN ISO 19119. Version 1.1",
                 "rawDate": "2009-02-18",
                 "publisher": "European Commission",
@@ -3823,7 +3823,7 @@
                 ]
             },
             "20100616": {
-                "href": "http://inspire.ec.europa.eu/documents/Metadata/INSPIRE_MD_IR_and_ISO_v1_2_20100616.pdf",
+                "href": "https://inspire.ec.europa.eu/documents/Metadata/INSPIRE_MD_IR_and_ISO_v1_2_20100616.pdf",
                 "title": "INSPIRE Metadata Implementing Rules: Technical Guidelines based on EN ISO 19115 and EN ISO 19119. Version 1.2",
                 "rawDate": "2010-06-16",
                 "publisher": "European Commission",
@@ -3832,7 +3832,7 @@
                 ]
             },
             "20131029": {
-                "href": "http://inspire.ec.europa.eu/documents/Metadata/MD_IR_and_ISO_20131029.pdf",
+                "href": "https://inspire.ec.europa.eu/documents/Metadata/MD_IR_and_ISO_20131029.pdf",
                 "title": "INSPIRE Metadata Implementing Rules: Technical Guidelines based on EN ISO 19115 and EN ISO 19119. Version 1.3",
                 "rawDate": "2013-10-29",
                 "publisher": "European Commission",
@@ -3841,7 +3841,7 @@
                 ]
             },
             "20170302": {
-                "href": "https://inspire.ec.europa.eu/file/1705/download?token=iSTwpRWd",
+                "href": "https://inspire.ec.europa.eu/id/document/tg/metadata-iso19139/2.0.1",
                 "title": "Technical Guidance for the implementation of INSPIRE dataset and service metadata based on ISO/TS 19139:2007. Version 2.0.1",
                 "rawDate": "2017-03-02",
                 "publisher": "European Commission",


### PR DESCRIPTION
- Replaced `href` field value in [entry `INSPIRE-MD-20170302`](https://api.specref.org/bibrefs?refs=inspire-md-20170302) with persistent versioned URI
- s/http:/https:/ in `href` field values in [all `INSPIRE-MD` entries](https://api.specref.org/bibrefs?refs=inspire-md)