### PR TITLE
Update info about Web Share Target API spec

### DIFF
--- a/overwrites/wicg.json
+++ b/overwrites/wicg.json
@@ -1,3 +1,3 @@
 [
-    { "id": "TRUSTED-TYPES", "action": "delete" }
+    { "id": "WEB-SHARE-TARGET", "action": "delete" }
 ]

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2943,6 +2943,17 @@
     "WCAG": {
         "aliasOf": "WAI-WEBCONTENT"
     },
+    "WEB-SHARE-TARGET": {
+        "authors": [
+            "Matt Giuca",
+            "Eric Willigers"
+        ],
+        "href": "https://w3c.github.io/web-share-target/",
+        "title": "Web Share Target API",
+        "status": "ED",
+        "publisher": "W3C",
+        "repository": "https://github.com/w3c/web-share-target"
+    },
     "WEB-SQL": {
         "aliasOf": "webdatabase"
     },

--- a/refs/wicg.json
+++ b/refs/wicg.json
@@ -279,14 +279,6 @@
         "source": "https://wicg.github.io/admin/biblio.json",
         "repository": "https://github.com/wicg/web-locks"
     },
-    "WEB-SHARE-TARGET": {
-        "href": "https://wicg.github.io/web-share-target/",
-        "title": "Web Share Target API",
-        "status": "cg-draft",
-        "publisher": "WICG",
-        "source": "https://wicg.github.io/admin/biblio.json",
-        "repository": "https://github.com/wicg/web-share-target"
-    },
     "WEBUSB": {
         "href": "https://wicg.github.io/webusb/",
         "title": "WebUSB API",


### PR DESCRIPTION
Spec migrated from WICG to WebApps WG:
https://github.com/w3c/web-share-target/issues/87

This update also drops the WICG overwrite on TRUSTED-TYPES which is no longer needed (entry was removed from source WICG biblio file).