### PR TITLE
Update Badging API info

### DIFF
--- a/overwrites/wicg.json
+++ b/overwrites/wicg.json
@@ -1,3 +1,3 @@
 [
-    { "id": "WEB-SHARE-TARGET", "action": "delete" }
+    { "id": "BADGING", "action": "delete" }
 ]

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -176,6 +176,17 @@
         "publisher": "Adobe Systems Incorporated",
         "date": "May 2005"
     },
+    "BADGING": {
+        "authors": [
+            "Matt Giuca",
+            "Jay Harris"
+        ],
+        "href": "https://w3c.github.io/badging/",
+        "title": "Badging API",
+        "status": "ED",
+        "publisher": "W3C",
+        "repository": "https://github.com/w3c/badging"
+    },
     "BBC-SUBTITLE": {
         "href": "https://bbc.github.io/subtitle-guidelines/",
         "title": "Subtitle Guidelines, Version 1.1.7",

--- a/refs/wicg.json
+++ b/refs/wicg.json
@@ -15,14 +15,6 @@
         "source": "https://wicg.github.io/admin/biblio.json",
         "repository": "https://github.com/wicg/background-fetch"
     },
-    "BADGING": {
-        "href": "https://wicg.github.io/badging/",
-        "title": "Badging API",
-        "status": "cg-draft",
-        "publisher": "WICG",
-        "source": "https://wicg.github.io/admin/biblio.json",
-        "repository": "https://github.com/wicg/badging"
-    },
     "BUDGET-API": {
         "href": "https://wicg.github.io/budget-api/",
         "title": "Web Budget API",


### PR DESCRIPTION
Spec migrated from WICG to WebApps WG (no FPWD for now):
https://github.com/w3c/badging/pull/70

The update also removes the overwrite for Web Share Target, which is no longer needed.