### PR TITLE
Mark WICG GEOLOCATION SENSOR as alias of W3C's version

### DIFF
--- a/refs/wicg.json
+++ b/refs/wicg.json
@@ -332,13 +332,8 @@
         "source": "https://wicg.github.io/admin/biblio.json",
         "repository": "https://github.com/wicg/frame-timing"
     },
-    "WICG-GEOLOCATION-SENSOR": {
-        "href": "https://wicg.github.io/geolocation-sensor/",
-        "title": "Geolocation Sensor",
-        "status": "cg-draft",
-        "publisher": "WICG",
-        "source": "https://wicg.github.io/admin/biblio.json",
-        "repository": "https://github.com/wicg/geolocation-sensor"
+  "WICG-GEOLOCATION-SENSOR": {
+        "aliasOf": "geolocation-sensor"
     },
     "WICG-INPUT-DEVICE-CAPABILITIES": {
         "aliasOf": "INPUT-DEVICE-CAPABILITIES"


### PR DESCRIPTION
Got migrated out of WICG a while ago and https://wicg.github.io/geolocation-sensor/ redirects to https://w3c.github.io/geolocation-sensor/