### PR TITLE
Fix and update source URL in csswg.json

### DIFF
--- a/refs/csswg.json
+++ b/refs/csswg.json
@@ -1,12 +1,12 @@
 {
     "AAT-FEATURES": {
-        "source": "http://dev.w3.org/csswg/biblio.ref",
+        "source": "https://drafts.csswg.org/biblio.ref",
         "title": "Apple Advanced Typography Font Feature Registry",
         "publisher": "Apple",
         "href": "https://developer.apple.com/fonts/TrueType-Reference-Manual/RM09/AppendixF.html"
     },
     "ACEBAL2010": {
-        "source": "http://dev.w3.org/csswg/biblio.ref",
+        "source": "https://drafts.csswg.org/biblio.ref",
         "title": "ALMcss: Separación de estructura y presentación en la web mediante posicionamiento avanzado en CSS",
         "authors": [
             "César Fernández Acebal"
@@ -15,7 +15,7 @@
         "href": "http://di002.edv.uniovi.es/~acebal/phd/dissertation.pdf"
     },
     "ACEBAL2012": {
-        "source": "http://dev.w3.org/csswg/biblio.ref",
+        "source": "https://drafts.csswg.org/biblio.ref",
         "title": "ALMcss: a Javascript implementation of the CSS template layout module",
         "authors": [
             "César Acebal",
@@ -27,7 +27,7 @@
         "publisher": "ACM"
     },
     "CJKV-INFO-PROCESSING": {
-        "source": "http://dev.w3.org/csswg/biblio.ref",
+        "source": "https://drafts.csswg.org/biblio.ref",
         "authors": [
             "Ken Lunde"
         ],
@@ -36,7 +36,7 @@
         "rawDate": "2009"
     },
     "CSS-EXTENSIONS": {
-        "source": "http://dev.w3.org/csswg/biblio.ref",
+        "source": "https://drafts.csswg.org/biblio.ref",
         "title": "CSS Extensions",
         "authors": [
             "Tab Atkins Jr."
@@ -47,7 +47,7 @@
         "repository": "https://github.com/w3c/csswg-drafts"
     },
     "CSS3-PAGE-TEMPLATE": {
-        "source": "http://dev.w3.org/csswg/biblio.ref",
+        "source": "https://drafts.csswg.org/biblio.ref",
         "title": "CSS Pagination Templates Module Level 3",
         "authors": [
             "Alan Stearns"
@@ -57,7 +57,7 @@
         "repository": "https://github.com/w3c/csswg-drafts"
     },
     "CSS4BACKGROUND": {
-        "source": "http://dev.w3.org/csswg/biblio.ref",
+        "source": "https://drafts.csswg.org/biblio.ref",
         "title": "CSS Backgrounds and Borders Module Level 4",
         "authors": [
             "Elika J. Etemad",
@@ -68,7 +68,7 @@
         "repository": "https://github.com/w3c/csswg-drafts"
     },
     "DIGITAL-TYPOGRAPHY": {
-        "source": "http://dev.w3.org/csswg/biblio.ref",
+        "source": "https://drafts.csswg.org/biblio.ref",
         "authors": [
             "Richard Rubinstein"
         ],
@@ -83,7 +83,7 @@
         "href": "http://www.color.org/specification/ICC1v43_2010-12.pdf"
     },
     "JUSTIFY": {
-        "source": "http://dev.w3.org/csswg/biblio.ref",
+        "source": "https://drafts.csswg.org/biblio.ref",
         "authors": [
             "Elika Etemad",
             "Richard Ishida"
@@ -92,31 +92,31 @@
         "href": "https://www.w3.org/International/articles/typography/justification"
     },
     "OPEN-FONT-FORMAT": {
-        "source": "http://dev.w3.org/csswg/biblio.ref",
+        "source": "https://drafts.csswg.org/biblio.ref",
         "title": "Information technology — Coding of audio-visual objects — Part 22: Open Font Format",
         "publisher": "International Organization for Standardization.",
         "href": "http://standards.iso.org/ittf/PubliclyAvailableStandards/c052136_ISO_IEC_14496-22_2009%28E%29.zip"
     },
     "OPENTYPE": {
-        "source": "http://dev.w3.org/csswg/biblio.ref",
+        "source": "https://drafts.csswg.org/biblio.ref",
         "title": "OpenType specification",
         "publisher": "Microsoft",
         "href": "http://www.microsoft.com/typography/otspec/default.htm"
     },
     "OPENTYPE-FEATURES": {
-        "source": "http://dev.w3.org/csswg/biblio.ref",
+        "source": "https://drafts.csswg.org/biblio.ref",
         "title": "OpenType feature registry",
         "publisher": "Microsoft",
         "href": "http://www.microsoft.com/typography/otspec/featurelist.htm"
     },
     "OPENTYPE-FONT-GUIDE": {
-        "source": "http://dev.w3.org/csswg/biblio.ref",
+        "source": "https://drafts.csswg.org/biblio.ref",
         "title": "OpenType User Guide",
         "publisher": "FontShop International",
         "href": "https://www.fontfont.com/staticcontent/downloads/FF_OT_User_Guide.pdf"
     },
     "PORTERDUFF": {
-        "source": "http://dev.w3.org/csswg/biblio.ref",
+        "source": "https://drafts.csswg.org/biblio.ref",
         "title": "Compositing digital images",
         "authors": [
             "Thomas Porter",
@@ -126,7 +126,7 @@
         "rawDate": "1984-07"
     },
     "RASTER-TRAGEDY": {
-        "source": "http://dev.w3.org/csswg/biblio.ref",
+        "source": "https://drafts.csswg.org/biblio.ref",
         "title": "The Raster Tragedy at Low-Resolution Revisited",
         "authors": [
             "Beat Stamm"
@@ -141,7 +141,7 @@
         "href": "http://www.itu.int/rec/R-REC-BT.2020/en"
     },
     "WINDOWS-GLYPH-PROC": {
-        "source": "http://dev.w3.org/csswg/biblio.ref",
+        "source": "https://drafts.csswg.org/biblio.ref",
         "title": "Windows Glyph Processing",
         "authors": [
             "John Hudson"

--- a/scripts/csswg.js
+++ b/scripts/csswg.js
@@ -43,7 +43,7 @@ var REJECT = {
     "XML10-4e": true
 }
 
-var REF_URL = "https://dev.w3.org/csswg/biblio.ref";
+var REF_URL = "https://drafts.csswg.org/biblio.ref";
 
 console.log("Updating CSS WG refs...");
 console.log("Fetching", REF_URL + "...");


### PR DESCRIPTION
[Last update to the script](https://github.com/tobie/specref/commit/2d91325602246955ba2f68675989426c37e2e4da) moved the `biblio.ref` URL to HTTPS but did not update the source URL of all entries in `csswg.json`, which stuck to the HTTP one. This meant that the script could no longer integrate updates from `biblio.ref` (there haven't been any since then in practice, so nothing got missed).

This update switches the source URL to HTTPS, and updates it since it now is a redirect to https://drafts.csswg.org/biblio.ref

Note the `biblio.ref` file does not seem to be maintained anymore in practice so it's not entirely clear whether this should still considered to be a source, or whether the info in Specref actually becomes the source... see discussion at https://github.com/w3c/csswg-drafts/pull/5194#issuecomment-643397000