### PR TITLE
Drop W3C overwrites for hr-time

### DIFF
--- a/overwrites/w3c.json
+++ b/overwrites/w3c.json
@@ -8,10 +8,7 @@
   { "id": "notifications",     "action": "delete" },
   { "id": "dom",               "action": "delete" },
   { "id": "encoding",          "action": "delete" },
-  { "id": "hr-time",           "action": "renameTo", "newId": "hr-time-1"},
   { "id": "hr-time",           "action": "createAlias", "aliasOf": "hr-time-2"},
-  { "id": "hr-time-1",         "action": "replaceProp", "prop": "href", "value": "https://www.w3.org/TR/hr-time-1/" },
-  { "id": "hr-time-2",         "action": "replaceProp", "prop": "obsoletes", "value": ["hr-time-1"] },
   { "id": "service-workers-1", "action": "replaceProp", "prop": "edDraft", "value": "https://w3c.github.io/ServiceWorker/" },
   { "id": "xpath",             "action": "replaceProp", "prop": "href", "value": "https://www.w3.org/TR/xpath-10/" }
 ]


### PR DESCRIPTION
Info returned by W3C systems changed for hr-time, and the `renameTo` overwrite was creating an infinite loop (`hr-time-1` defined an alias of `hr-time-1`). The auto-update bot has been crashing in the past few days because of that.