### PR TITLE
Update biblio.json: ISO8601 got updated

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1745,6 +1745,22 @@
         "title": "Representation of dates and times. ISO 8601:2004.",
         "isoNumber": "ISO 8601:2004"
     },
+    "ISO8601-1": {
+        "href": "https://www.iso.org/standard/70907.html",
+        "publisher": "International Organization for Standardization (ISO)",
+        "date": "2019",
+        "status": "ISO 8601-1:2019",
+        "title": "Date and time — Representations for information interchange — Part 1: Basic rules. ISO 8601-1:2019.",
+        "isoNumber": "ISO 8601-1:2019"
+    },
+    "ISO8601-2": {
+        "href": "https://www.iso.org/standard/70908.html",
+        "publisher": "International Organization for Standardization (ISO)",
+        "date": "2019",
+        "status": "ISO 8601-2:2019",
+        "title": "Date and time — Representations for information interchange — Part 2: Extensions. ISO 8601-2:2019.",
+        "isoNumber": "ISO 8601-2:2019"
+    },
     "ISOBMFF": {
         "title": "Information technology — Coding of audio-visual objects — Part 12: ISO Base Media File Format",
         "href": "http://standards.iso.org/ittf/PubliclyAvailableStandards/c068960_ISO_IEC_14496-12_2015.zip",


### PR DESCRIPTION
ISO 8601:2004 got updated and also split into two (8601-1:2019 and 8601-2:2019). I used the 8601-1 and 8601-2 keys and I left the 8601 with the old reference. Whoever reviews this can say (and possible change the submission) whether it is would be correct to use 8601 as a synonym for 8601-1, thereby removing the old version...