### PR TITLE
add entry for RDF-STAR-FOUNDATION

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2444,6 +2444,13 @@
     "RDF-SYNTAX": {
         "aliasOf": "rdf-concepts"
     },
+    "RDF-STAR-FOUNDATION": {
+        "authors": [ "Olaf Hartig" ],
+        "title": "Foundations of RDF* and SPARQL* - An Alternative Approach to Statement-Level Metadata in RDF.",
+        "publisher": "In Proceedings of the 11th Alberto Mendelzon International Workshop on Foundations of Data Management (AMW), Montevideo, Uruguay",
+        "rawDate": "2017-06",
+        "href": "http://ceur-ws.org/Vol-1912/paper12.pdf"
+    },
     "RELAXNG-SCHEMA": {
         "title": "Information technology -- Document Schema Definition Language (DSDL) -- Part 2: Regular-grammar-based validation -- RELAX NG",
         "href": "http://standards.iso.org/ittf/PubliclyAvailableStandards/c052348_ISO_IEC_19757-2_2008(E).zip",


### PR DESCRIPTION
 Olaf Hartig: Foundations of RDF* and SPARQL* - An Alternative Approach to Statement-Level Metadata in RDF. In Proceedings of the 11th Alberto Mendelzon International Workshop on Foundations of Data Management (AMW), Montevideo, Uruguay, June 2017 PDF file 