### PR TITLE
Add a reference for Spline/Scalable Font (SFNT)

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2651,6 +2651,13 @@
     "SELECTORS-LEVEL-3": {
         "aliasOf": "css3-selectors"
     },
+    "SFNT": {
+      "title": "Spline/Scalable font format",
+      "href": "https://www.iso.org/obp/ui/#iso:std:iso-iec:14496:-22:ed-4:v1:en",
+      "publisher": "ISO",
+      "rawDate": "2019-01",
+      "isoNumber": "ISO/IEC 14496-22:2019"
+    },
     "SGML-CATALOG": {
         "title": "Entity Management: OASIS Technical Resolution 9401:1997 (Amendment 2 to TR 9401)",
         "href": "https://www.oasis-open.org/specs/a401.htm",


### PR DESCRIPTION
The SFNT file format is the standard container format for various font
formats such as OpenType, TrueType, Postscript, WOFF, etc.

It is important to be able to reference this format when discussing
the low-level concepts of fonts.