### PR TITLE
Revert "`vocab-dcat` should be an alias for the version 2"

### DIFF
--- a/overwrites/w3c.json
+++ b/overwrites/w3c.json
@@ -10,6 +10,5 @@
   { "id": "encoding",          "action": "delete" },
   { "id": "hr-time",           "action": "createAlias", "aliasOf": "hr-time-2"},
   { "id": "service-workers-1", "action": "replaceProp", "prop": "edDraft", "value": "https://w3c.github.io/ServiceWorker/" },
-  { "id": "xpath",             "action": "replaceProp", "prop": "href", "value": "https://www.w3.org/TR/xpath-10/" },
-  { "id": "vocab-dcat",        "action": "createAlias", "aliasOf": "vocab-dcat-2"},
+  { "id": "xpath",             "action": "replaceProp", "prop": "href", "value": "https://www.w3.org/TR/xpath-10/" }
 ]


### PR DESCRIPTION
Reverts tobie/specref#635

This seems to be breaking things.