### PR TITLE
`voocab-dcat` should be an alias for the version 2

### DIFF
--- a/overwrites/w3c.json
+++ b/overwrites/w3c.json
@@ -10,5 +10,6 @@
   { "id": "encoding",          "action": "delete" },
   { "id": "hr-time",           "action": "createAlias", "aliasOf": "hr-time-2"},
   { "id": "service-workers-1", "action": "replaceProp", "prop": "edDraft", "value": "https://w3c.github.io/ServiceWorker/" },
-  { "id": "xpath",             "action": "replaceProp", "prop": "href", "value": "https://www.w3.org/TR/xpath-10/" }
+  { "id": "xpath",             "action": "replaceProp", "prop": "href", "value": "https://www.w3.org/TR/xpath-10/" },
+  { "id": "vocab-dcat",        "action": "createAlias", "aliasOf": "vocab-dcat-2"}
 ]


### PR DESCRIPTION
@andrea-perego mentioned that vocab-dcat should point to version 2 in w3c/w3c-api#96

This was previously merged and reverted.