### PR TITLE
Update JSON alias to RFC8259

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1854,7 +1854,7 @@
         "status": "Report (draft) ISO/IEC CD15444-1:1999"
     },
     "JSON": {
-        "aliasOf": "RFC4627"
+        "aliasOf": "RFC8259"
     },
     "JSON-LD-TESTS": {
         "authors": [


### PR DESCRIPTION
The JSON alias was pointing to obsolete RFC. This now points to the latest IETF standard. 