### PR TITLE
Use datatracker.ietf.org URLs for IETF documents

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -224,7 +224,7 @@
             "A. Phillips",
             "M. Davis"
         ],
-        "href": "https://tools.ietf.org/html/bcp47",
+        "href": "https://datatracker.ietf.org/doc/html/bcp47",
         "title": "Tags for Identifying Languages",
         "date": "September 2009",
         "status": "IETF Best Current Practice",
@@ -256,7 +256,7 @@
             "C. Jennings"
         ],
         "date": "31 August 2017",
-        "href": "https://tools.ietf.org/html/draft-ietf-mmusic-sdp-bundle-negotiation",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-mmusic-sdp-bundle-negotiation",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Negotiating Media Multiplexing Using the Session Description Protocol (SDP)"
@@ -388,7 +388,7 @@
             "E Shelby"
         ],
         "etAl": true,
-        "href": "https://tools.ietf.org/html/draft-ietf-core-coap",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-core-coap",
         "title": "Constrained Application Protocol (CoAP)",
         "date": "December 2012",
         "status": "Internet Draft",
@@ -1366,7 +1366,7 @@
     },
     "FLEXFEC": {
         "title": "RTP Payload Format for Flexible Forward Error Correction (FEC)",
-        "href": "https://tools.ietf.org/html/draft-ietf-payload-flexible-fec-scheme",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-payload-flexible-fec-scheme",
         "authors": [
             "V. Singh",
             "A. Begen",
@@ -1510,7 +1510,7 @@
             "R. Pantos",
             "W. May"
         ],
-        "href": "https://tools.ietf.org/html/draft-pantos-http-live-streaming",
+        "href": "https://datatracker.ietf.org/doc/html/draft-pantos-http-live-streaming",
         "title": "HTTP Live Streaming (HLS)",
         "date": "15 October 2012",
         "status": "Internet Draft",
@@ -1554,7 +1554,7 @@
             "J. Reschke"
         ],
         "date": "24 October 2017",
-        "href": "https://tools.ietf.org/html/draft-reschke-http-jfv",
+        "href": "https://datatracker.ietf.org/doc/html/draft-reschke-http-jfv",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "A JSON Encoding for HTTP Header Field Values"
@@ -1880,7 +1880,7 @@
             "Mike Jones"
         ],
         "date": "28 May 2013",
-        "href": "https://tools.ietf.org/html/draft-ietf-jose-json-web-key-11",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-jose-json-web-key-11",
         "publisher": "IETF",
         "status": "Internet Draft",
         "title": "JSON Web Key (JWK)"
@@ -1892,7 +1892,7 @@
             "N. Sakimura"
         ],
         "date": "6 July 2012",
-        "href": "https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-01",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-oauth-json-web-token-01",
         "publisher": "IETF",
         "status": "Internet Draft",
         "title": "JSON Web Token (JWT)"
@@ -2481,7 +2481,7 @@
             "M. Thomson"
         ],
         "date": "23 July 2014",
-        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-alpn",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-rtcweb-alpn",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Application Layer Protocol Negotiation for Web Real-Time Communications"
@@ -2494,7 +2494,7 @@
             "Dan Burnett"
         ],
         "date": "4 July 2014",
-        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-constraints-registry",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-rtcweb-constraints-registry",
         "publisher": "IETF",
         "status": "Internet Draft (work in progress)",
         "title": "IANA Registry for RTCWeb Constrainable Properties"
@@ -2506,7 +2506,7 @@
             "M. Tuexen"
         ],
         "date": "14 October 2015",
-        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-data-channel",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-rtcweb-data-channel",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "RTCWeb Data Channels"
@@ -2518,7 +2518,7 @@
             "M. Tuexen"
         ],
         "date": "14 October 2015",
-        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-data-protocol",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-rtcweb-data-protocol",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "RTCWeb Data Channel Protocol"
@@ -2529,7 +2529,7 @@
             "Justin Uberti"
         ],
         "date": "20 March 2016",
-        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-ip-handling",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-rtcweb-ip-handling",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "WebRTC IP Address Handling Recommendations"
@@ -2540,7 +2540,7 @@
             "Cullen Jennings"
         ],
         "date": "22 October 2013",
-        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-jsep",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-rtcweb-jsep",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Javascript Session Establishment Protocol"
@@ -2550,7 +2550,7 @@
             "H. Alvestrand"
         ],
         "date": "14 February 2014",
-        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-overview",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-rtcweb-overview",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Overview: Real Time Protocols for Brower-based Applications"
@@ -2562,7 +2562,7 @@
             "J. Ott"
         ],
         "date": "17 March 2016",
-        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-rtp-usage",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-rtcweb-rtp-usage",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Web Real-Time Communication (WebRTC): Media Transport and Use of RTP"
@@ -2572,7 +2572,7 @@
             "Eric Rescorla"
         ],
         "date": "22 January 2014",
-        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-security",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-rtcweb-security",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Security Considerations for WebRTC"
@@ -2582,7 +2582,7 @@
             "Eric Rescorla"
         ],
         "date": "10 December 2016",
-        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-security-arch",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-rtcweb-security-arch",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "WebRTC Security Architecture"
@@ -2592,7 +2592,7 @@
             "H. Alvestrand"
         ],
         "date": "31 October 2016",
-        "href": "https://tools.ietf.org/html/draft-ietf-rtcweb-transports",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-rtcweb-transports",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Transports for RTCWEB"
@@ -2623,7 +2623,7 @@
             "G. Camarillo"
         ],
         "date": "20 March 2017",
-        "href": "https://tools.ietf.org/html/draft-ietf-mmusic-sctp-sdp",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-mmusic-sctp-sdp",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Session Description Protocol (SDP) Offer/Answer Procedures For Stream Control Transmission Protocol (SCTP) over Datagram Transport Layer Security (DTLS) Transport"
@@ -2639,7 +2639,7 @@
             "M. Zanaty"
         ],
         "date": "27 June 2018",
-        "href": "https://tools.ietf.org/html/draft-ietf-mmusic-sdp-simulcast",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-mmusic-sdp-simulcast",
         "publisher": "IETF",
         "status": "Active Internet-Draft",
         "title": "Using Simulcast in SDP and RTP Sessions"
@@ -2781,7 +2781,7 @@
             "P. Matthews"
         ],
         "date": "16 February 2017",
-        "href": "https://tools.ietf.org/html/draft-ietf-tram-stunbis",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-tram-stunbis",
         "publisher": "IETF",
         "status": "Internet Draft (work in progress)",
         "title": "Session Traversal Utilities for NAT (STUN)"
@@ -2793,7 +2793,7 @@
             "P. Jones",
             "and M. Petit-Huguenin"
         ],
-        "href": "https://tools.ietf.org/html/draft-nandakumar-rtcweb-stun-uri",
+        "href": "https://datatracker.ietf.org/doc/html/draft-nandakumar-rtcweb-stun-uri",
         "title": "URI Scheme for Session Traversal Utilities for NAT (STUN) Protocol",
         "date": "12 March 2012",
         "status": "Internet Draft (work in progress)",
@@ -2863,7 +2863,7 @@
             "P. Saint-Andre"
         ],
         "date": "15 April 2018",
-        "href": "https://tools.ietf.org/html/draft-ietf-ice-trickle-21",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-ice-trickle-21",
         "publisher": "IETF",
         "status": "Internet Draft (work in progress)",
         "title": "Trickle ICE: Incremental Provisioning of Candidates for the Interactive Connectivity Establishment (ICE) Protocol"
@@ -2893,7 +2893,7 @@
             "J. Polk"
         ],
         "date": "22 August 2016",
-        "href": "https://tools.ietf.org/html/draft-ietf-tsvwg-rtcweb-qos",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-tsvwg-rtcweb-qos",
         "publisher": "IETF",
         "status": "Internet Draft (work in progress)",
         "title": "DSCP Packet Markings for WebRTC QoS"
@@ -2909,7 +2909,7 @@
             "J. Rosenberg"
         ],
         "date": "11 October 2018",
-        "href": "https://tools.ietf.org/html/draft-ietf-tram-turnbis",
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-tram-turnbis",
         "publisher": "IETF",
         "status": "Internet Draft (work in progress)",
         "title": "Traversal Using Relays around NAT (TURN): Relay Extensions to Session Traversal Utilities for NAT (STUN)"
@@ -2921,7 +2921,7 @@
             "G. Salgueiro",
             "and  P. Jones"
         ],
-        "href": "https://tools.ietf.org/html/draft-petithuguenin-behave-turn-uris",
+        "href": "https://datatracker.ietf.org/doc/html/draft-petithuguenin-behave-turn-uris",
         "title": "Traversal Using Relays around NAT (TURN) Uniform Resource Identifiers",
         "date": "12 March 2012",
         "status": "Internet Draft (work in progress)",
@@ -3915,7 +3915,7 @@
             "Mark Cavage",
             "Manu Sporny"
         ],
-        "href": "https://tools.ietf.org/html/draft-cavage-http-signatures",
+        "href": "https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures",
         "title": "HTTP Signatures",
         "status": "WD",
         "publisher": "IETF",
@@ -3928,7 +3928,7 @@
                     "Mark Cavage",
                     "Manu Sporny"
                 ],
-                "href": "https://tools.ietf.org/html/draft-cavage-http-signatures-00",
+                "href": "https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-00",
                 "title": "HTTP Signatures",
                 "rawDate": "2013-05-04",
                 "publisher": "IETF",
@@ -4512,7 +4512,7 @@
         "authors": [
             "K. Zyp"
         ],
-        "href": "https://tools.ietf.org/html/draft-zyp-json-schema",
+        "href": "https://datatracker.ietf.org/doc/html/draft-zyp-json-schema",
         "publisher": "Internet Engineering Task Force (IETF)",
         "status": "Internet-Draft",
         "rawDate": "2013-01-31",

--- a/scripts/ietf.js
+++ b/scripts/ietf.js
@@ -82,7 +82,7 @@ function href(index) {
     if (HTTP_SPECS.indexOf(index) > -1) {
         return "https://httpwg.org/specs/" + index + ".html";
     }
-    return "https://tools.ietf.org/html/" + unpad(index);
+    return "https://datatracker.ietf.org/doc/html/" + unpad(index);
 }
 
 function unpad(index) {


### PR DESCRIPTION
tools.ietf.org is no longer to be relied on per https://mailarchive.ietf.org/arch/msg/tools-discuss/oYrAxb3KayPzZ4SNB1DVZTDPPNo/