### PR TITLE
alias hr-time to hr-time-3

### DIFF
--- a/overwrites/w3c.json
+++ b/overwrites/w3c.json
@@ -8,6 +8,7 @@
   { "id": "notifications",     "action": "delete" },
   { "id": "dom",               "action": "delete" },
   { "id": "encoding",          "action": "delete" },
+  { "id": "hr-time",           "action": "createAlias", "aliasOf": "hr-time-3"},
   { "id": "resource-timing",   "action": "createAlias", "aliasOf": "resource-timing-2"},
   { "id": "service-workers-1", "action": "replaceProp", "prop": "edDraft", "value": "https://w3c.github.io/ServiceWorker/" },
   { "id": "xpath",             "action": "replaceProp", "prop": "href", "value": "https://www.w3.org/TR/xpath-10/" }


### PR DESCRIPTION
specref relies on [tr.rdf](https://www.w3.org/2002/01/tr-automation/tr.rdf) which doesn't manage the specification series.
[Goal](https://github.com/tobie/specref/issues/612) is to rely on the W3C API instead. In the meantime, the alias for `hr-time` is still needed.