### PR TITLE
Switch URL of ecma262 spec to multipage version

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1085,7 +1085,7 @@
     },
     "ECMASCRIPT": {
         "title": "ECMAScript Language Specification",
-        "href": "https://tc39.es/ecma262/",
+        "href": "https://tc39.es/ecma262/multipage/",
         "publisher": "Ecma International",
         "versions": {
             "51": {


### PR DESCRIPTION
A multipage version of the ECMAScript spec now exists. Switch is motivated by performance reason, as with the HTML spec.

For additional context, see https://github.com/mdn/browser-compat-data/pull/10615 and https://github.com/w3c/browser-specs/pull/299