### PR TITLE
Add references to MapML and UCR-Web-Maps

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1903,6 +1903,21 @@
         "status": "W3C Incubator Group Report",
         "publisher": "W3C"
     },
+    "MapML": {
+        "authors": [
+            "Peter Rushforth",
+            "Robert Linder",
+            "Joan Masó"
+        ],
+        "href": "https://maps4html.org/MapML/spec/",
+        "title": "Map Markup Language (MapML) specification",
+        "publisher": "W3C Maps for HTML Community Group",
+        "deliveredBy": [
+            "https://maps4html.org/"
+        ],
+        "status": "Draft Community Group Report",
+        "repository": "https://github.com/Maps4HTML/MapML/"
+    },
     "MDNS": {
         "aliasOf": "RFC6762"
     },

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -4701,6 +4701,23 @@
         "status": "Khronos Working Draft",
         "publisher": "Khronos"
     },
+    "UCR-Web-Maps": {
+        "authors": [
+            "Amelia Bellamy-Royds",
+            "Nic Chan",
+            "Nick Fitzsimons",
+            "Peter Rushforth",
+            "Robert Linder"
+        ],
+        "href": "https://maps4html.org/HTML-Map-Element-UseCases-Requirements/",
+        "title": "Use Cases and Requirements for Standardizing Web Maps",
+        "publisher": "W3C Maps for HTML Community Group",
+        "deliveredBy": [
+            "https://maps4html.org/"
+        ],
+        "status": "Draft Community Group Report",
+        "repository": "https://github.com/Maps4HTML/HTML-Map-Element-UseCases-Requirements/"
+    },
     "uml": {
         "authors": [
             "Open Management Group"


### PR DESCRIPTION
Adds references to 2 deliverables by the W3C [Maps for HTML Community Group](https://www.w3.org/community/maps4html/):

- [Map Markup Language (MapML) specification](https://maps4html.org/MapML/spec/)
- [Use Cases and Requirements for Standardizing Web Maps](https://maps4html.org/HTML-Map-Element-UseCases-Requirements/)