### PR TITLE
Use rfc-editor.org URLs instead of datatracker.ietf.org for IETF RFCs

### DIFF
--- a/scripts/ietf.js
+++ b/scripts/ietf.js
@@ -82,7 +82,7 @@ function href(index) {
     if (HTTP_SPECS.indexOf(index) > -1) {
         return "https://httpwg.org/specs/" + index + ".html";
     }
-    return "https://datatracker.ietf.org/doc/html/" + unpad(index);
+    return "https://www.rfc-editor.org/rfc/" + unpad(index);
 }
 
 function unpad(index) {


### PR DESCRIPTION
Both are as authoritative as it gets, and from RFC8650 onwards, rfc-editor.org provide much nicer HTML rendering, as described in https://www.rfc-editor.org/format-live/

See also https://github.com/w3c/browser-specs/issues/342