### PR TITLE
fix(scripts/w3c): allow data to be in bibref

### DIFF
--- a/scripts/w3c.js
+++ b/scripts/w3c.js
@@ -242,17 +242,17 @@ request({
                     }
                 }
             } catch(e) {
-                if (aliasShortname in bibref.get(aliasShortname)) {
-                  return;
-                }
                 var root = current[leveled.getRootShortname(aliasShortname)];
                 if (!root || !root.versions || !root.versions[getKey(aliasShortname)]) {
+                    if (aliasShortname in bibref.get(aliasShortname)) {
+                        return;
+                    }
                     throw new Error("Missing data for spec " + aliasShortname);
                 }
             }
             current[k] = { aliasOf: leveled.isLevel(aliasShortname) ? leveled.getRootShortname(aliasShortname) : aliasShortname };
         });
-        
+
         Object.keys(levels).forEach(function(k) {
             current[k] =  { aliasOf: levels[k] };
         });


### PR DESCRIPTION
@tobie, is this too offensive? 

Basically, "check if data is in w3c.json... it's not... so maybe it's in bibref itself?"... 

Potential issue, subsequent script deletes the missing entry from bibref (low risk?). 