### PR TITLE
Move Web Locks API to biblio and update URL

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2890,6 +2890,17 @@
     "WCAG": {
         "aliasOf": "WAI-WEBCONTENT"
     },
+    "WEB-LOCKS": {
+        "authors": [
+            "Joshua Bell",
+            "Kagami Rosylight"
+        ],
+        "href": "https://w3c.github.io/web-locks/",
+        "title": "Web Locks API",
+        "status": "ED",
+        "publisher": "W3C",
+        "repository": "https://github.com/w3c/web-locks"
+    },
     "WEB-SHARE-TARGET": {
         "authors": [
             "Matt Giuca",

--- a/refs/wicg.json
+++ b/refs/wicg.json
@@ -295,14 +295,6 @@
         "source": "https://wicg.github.io/admin/biblio.json",
         "repository": "https://github.com/wicg/background-sync"
     },
-    "WEB-LOCKS": {
-        "href": "https://wicg.github.io/web-locks/",
-        "title": "Web Locks API",
-        "status": "cg-draft",
-        "publisher": "WICG",
-        "source": "https://wicg.github.io/admin/biblio.json",
-        "repository": "https://github.com/wicg/web-locks"
-    },
     "WEBUSB": {
         "href": "https://wicg.github.io/webusb/",
         "title": "WebUSB API",


### PR DESCRIPTION
The Web Locks API transitioned from WICG to the Web Applications Working Group a few weeks ago, where it exists as an Editor's Draft, see:
https://github.com/w3c/web-locks/issues/99

This update drops the entry from the wicg.json file (note the source biblio file from the WICG repo no longer contains Web Locks so fetch-refs won't add it again next time it runs), and adds it the biblio.json file under W3C with an updated w3c.github.io URL.