### PR TITLE
Add Frictionless Data Package

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1440,6 +1440,16 @@
             }
         }
     },
+    "FRICTIONLESS-DATA-PACKAGE": {
+        "authors": [
+            "Paul Walsh",
+            "Rufus Pollock"
+        ],
+        "href": "https://specs.frictionlessdata.io/data-package/",
+        "title": "Frictionless Data Package",
+        "publisher": "Open Knowledge Foundation",
+        "rawDate": "2017-05-02"
+    },
     "GEOLOCATION-PRIVACY": {
         "authors": [
             "Marcos Cáceres"


### PR DESCRIPTION
The Frictionless Data Package specification provides a pattern for bundling files and metadata describing those files together using JSON. It is published by the Open Knowledge Foundation. They have published other specifications but this is this is the only one I need right now.

Is this appropriate for `refs/biblio.json` @tobie?