### PR TITLE
Move Event Timing and Largest Contentful Paint to biblio

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1305,6 +1305,17 @@
     "ETSI103190-2": {
         "aliasOf": "etsi-ts-103-190-2"
     },
+    "EVENT-TIMING": {
+        "authors": [
+            "Nicolás Peña Moreno",
+            "Tim Dresser"
+        ],
+        "href": "https://w3c.github.io/event-timing/",
+        "title": "Event Timing API",
+        "status": "ED",
+        "publisher": "W3C",
+        "repository": "https://github.com/w3c/event-timing"
+    },
     "EVERGREEN-WEB": {
         "href": "https://www.w3.org/2001/tag/doc/evergreen-web/",
         "title": "The evergreen Web",
@@ -1910,6 +1921,17 @@
         "title": "Language Subtag Registry",
         "href": "http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry",
         "publisher": "IANA"
+    },
+    "LARGEST-CONTENTFUL-PAINT": {
+        "authors": [
+            "Yoav Weiss",
+            "Nicolás Peña Moreno"
+        ],
+        "href": "https://w3c.github.io/largest-contentful-paint/",
+        "title": "Largest Contentful Paint",
+        "status": "ED",
+        "publisher": "W3C",
+        "repository": "https://github.com/w3c/largest-contentful-paint"
     },
     "LDAP-DN": {
         "aliasOf": "RFC4514"

--- a/refs/wicg.json
+++ b/refs/wicg.json
@@ -79,14 +79,6 @@
         "source": "https://wicg.github.io/admin/biblio.json",
         "repository": "https://github.com/wicg/entries-api"
     },
-    "EVENT-TIMING": {
-        "href": "https://wicg.github.io/event-timing/",
-        "title": "Event Timing API",
-        "status": "cg-draft",
-        "publisher": "WICG",
-        "source": "https://wicg.github.io/admin/biblio.json",
-        "repository": "https://github.com/wicg/event-timing"
-    },
     "FILE-SYSTEM-ACCESS": {
         "href": "https://wicg.github.io/file-system-access/",
         "title": "File System Access",
@@ -142,14 +134,6 @@
         "publisher": "WICG",
         "source": "https://wicg.github.io/admin/biblio.json",
         "repository": "https://github.com/wicg/kv-storage"
-    },
-    "LARGEST-CONTENTFUL-PAINT": {
-        "href": "https://wicg.github.io/largest-contentful-paint/",
-        "title": "Largest Contentful Paint",
-        "status": "cg-draft",
-        "publisher": "WICG",
-        "source": "https://wicg.github.io/admin/biblio.json",
-        "repository": "https://github.com/wicg/largest-contentful-paint"
     },
     "LAYOUT-INSTABILITY": {
         "href": "https://wicg.github.io/layout-instability/",


### PR DESCRIPTION
The Event Timing and Largest Contentful Paint proposals migrated to a W3C WG. They got dropped from WICG's biblio in https://github.com/WICG/admin/pull/149

This update pushes them to the biblio file and updates their URLs to reflect the new w3c.github.io address.