### PR TITLE
Updating the entry for the ZIP file format

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -3390,8 +3390,8 @@
         "publisher": "IETF"
     },
     "ZIP": {
-        "date": "1 September 2012",
-        "href": "https://www.pkware.com/documents/casestudies/APPNOTE.TXT",
+        "date": "15 July 2020",
+        "href": "https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT",
         "status": "Final",
         "title": ".ZIP File Format Specification"
     },


### PR DESCRIPTION
The current URL (i.e., https://www.pkware.com/documents/casestudies/APPNOTE.TXT) is now a 404. The latest version seems to be https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT