### PR TITLE
Update BBC Subtitle Guidelines version and URL

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -188,10 +188,10 @@
         "repository": "https://github.com/w3c/badging"
     },
     "BBC-SUBTITLE": {
-        "href": "https://bbc.github.io/subtitle-guidelines/",
-        "title": "Subtitle Guidelines, Version 1.1.7",
+        "href": "https://www.bbc.co.uk/accessibility/forproducts/guides/subtitles/",
+        "title": "Subtitle Guidelines, Version 1.2.1",
         "publisher": "BBC",
-        "date": "May 2018",
+        "date": "July 2022",
         "repository": "https://github.com/bbc/subtitle-guidelines"
     },
     "BBC-WP193": {


### PR DESCRIPTION
BBC Subtitle Guidelines has moved location, and been updated. Use new URL and latest version number, 1.2.1 at time of this pull request.