### PR TITLE
Adding ECMAScript 13/ES2022

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1166,6 +1166,9 @@
             "2021": {
                 "aliasOf": "ECMASCRIPT-12.0"
             },
+            "2022": {
+                "aliasOf": "ECMASCRIPT-13.0"
+            },
             "5.1": {
                 "title": "ECMA-262 Edition 5.1, The ECMAScript Language Specification",
                 "rawDate": "2011-06",
@@ -1241,6 +1244,12 @@
                 "authors": [
                     "Jordan Harband"
                 ]
+            },
+            "13.0": {
+                "title": "ECMA-262 13th Edition, The ECMAScript 2022 Language Specification",
+                "rawDate": "2022-06",
+                "href": "https://262.ecma-international.org/13.0/",
+                "status": "Standard"
             }
         },
         "repository": "https://github.com/tc39/ecma262"


### PR DESCRIPTION
It appears the latest edition does not have an official Project Editor, so I did not include an "authors" section