### PR TITLE
Adjust URL and repo of Trusted Types

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2777,11 +2777,11 @@
             "Krzysztof Kotowicz",
             "Mike West"
         ],
-        "href": "https://w3c.github.io/webappsec-trusted-types/dist/spec/",
+        "href": "https://w3c.github.io/trusted-types/dist/spec/",
         "title": "Trusted Types",
         "status": "ED",
         "publisher": "W3C",
-        "repository": "https://github.com/w3c/webappsec-trusted-types/"
+        "repository": "https://github.com/w3c/trusted-types/"
     },
     "TSVWG-RTCWEB-QOS": {
         "aliasOf": "rfc8837"


### PR DESCRIPTION
The Github repository was renamed last week. This updates the URL of the spec and of the repository to reflect that change.

The spec should soon get published as a W3C First Public Working Draft so the entry will likely soon need to be deleted from the `biblio.json` file.