### PR TITLE
Add link to auto update script in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Unfortunately it doesn't use HTTPS yet.
 
 ### Hourly auto-updating
 
-There are scripts that pull fresh data from IETF, W3C, and WHATWG, and update their relevant files in the `refs` directory. These are now run hourly. Their output is tested, committed and deployed without human intervention. Content should now always be up to date.
+There are [scripts](scripts/run-all) that pull fresh data from IETF, W3C, WHATWG and WICG, and update their relevant files in the `refs` directory. These are now run hourly. Their output is tested, committed and deployed without human intervention. Content should now always be up to date.
 
 ### Manual changes
 


### PR DESCRIPTION
This helps viewers determine where specs should be listed to get pulled into SpecRef automatically.

Fixes: https://github.com/tobie/specref/issues/721