### PR TITLE
Additional citations use by RDF-star specs

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2496,7 +2496,7 @@
       "authors": ["Tim Berners-Lee"],
       "href": "https://www.w3.org/DesignIssues/RDFnot.html",
       "title": "What the Semantic Web can represent",
-      "date": "1998-09-17",
+      "rawDate": "1998-09-17",
       "status": "W3C-Internal Document",
       "publisher": "W3C"              
     },
@@ -2525,14 +2525,14 @@
       "editors": ["James Clark", "Murata Makoto"],
       "href": "http://www.oasis-open.org/committees/relax-ng/spec-20011203.html",
       "title": "RELAX NG Specification",
-      "date": "2001-12-03",
+      "rawDate": "2001-12-03",
       "publisher": "OASIS"
     },
     "RELAXNG-COMPACT": {
       "editors": ["James Clark"],
       "href": "http://www.oasis-open.org/committees/relax-ng/compact-20021121.html",
       "title": "RELAX NG Compact Syntax",
-      "date": "2002-11-21",
+      "rawDate": "2002-11-21",
       "publisher": "OASIS"
     },
     "RELAXNG-SCHEMA": {

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2521,6 +2521,20 @@
     "RDF11-XML": {
         "aliasOf": "rdf-syntax-grammar"
     },
+    "RELAXNG": {
+      "editors": ["James Clark", "Murata Makoto"],
+      "href": "http://www.oasis-open.org/committees/relax-ng/spec-20011203.html",
+      "title": "RELAX NG Specification",
+      "date": "2001-12-03",
+      "publisher": "OASIS"
+    },
+    "RELAXNG-COMPACT": {
+      "editors": ["James Clark"],
+      "href": "http://www.oasis-open.org/committees/relax-ng/compact-20021121.html",
+      "title": "RELAX NG Compact Syntax",
+      "date": "2002-11-21",
+      "publisher": "OASIS"
+    },
     "RELAXNG-SCHEMA": {
         "title": "Information technology -- Document Schema Definition Language (DSDL) -- Part 2: Regular-grammar-based validation -- RELAX NG",
         "href": "http://standards.iso.org/ittf/PubliclyAvailableStandards/c052348_ISO_IEC_19757-2_2008(E).zip",

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -222,6 +222,9 @@
     "BCP47": {
         "aliasOf": "rfc5646"
     },
+    "BERNERS-LEE98": {
+      "aliasOf": "RDF-NOT"
+    },
     "BIDI": {
         "aliasOf": "UAX9"
     },
@@ -2474,6 +2477,14 @@
     },
     "RDB2RDF-UC": {
         "aliasOf": "rdb2rdf-ucr"
+    },
+    "RDF-NOT": {
+      "authors": ["Tim Berners-Lee"],
+      "href": "https://www.w3.org/DesignIssues/RDFnot.html",
+      "title": "What the Semantic Web can represent",
+      "date": "1998-09-17",
+      "status": "W3C-Internal Document",
+      "publisher": "W3C"              
     },
     "RDF-SPARQL-UPDATE": {
         "aliasOf": "sparql11-update"

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2515,6 +2515,12 @@
     "RDF-SYNTAX": {
         "aliasOf": "rdf-concepts"
     },
+    "RDF-XML": {
+        "aliasOf": "rdf-syntax-grammar"
+    },
+    "RDF11-XML": {
+        "aliasOf": "rdf-syntax-grammar"
+    },
     "RELAXNG-SCHEMA": {
         "title": "Information technology -- Document Schema Definition Language (DSDL) -- Part 2: Regular-grammar-based validation -- RELAX NG",
         "href": "http://standards.iso.org/ittf/PubliclyAvailableStandards/c052348_ISO_IEC_19757-2_2008(E).zip",

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -4848,6 +4848,9 @@
         "publisher": "GFZ Potsdam",
         "rawDate": "2015-12-17"
     },
+    "rdf11-schema": {
+      "aliasOf": "rdf-schema"
+    },
     "rel-author": {
         "authors": [
             "Tantek Çelik"

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2522,7 +2522,7 @@
         "aliasOf": "rdf-syntax-grammar"
     },
     "RELAXNG": {
-      "editors": ["James Clark", "Murata Makoto"],
+      "authors": ["James Clark", "Murata Makoto"],
       "href": "http://www.oasis-open.org/committees/relax-ng/spec-20011203.html",
       "title": "RELAX NG Specification",
       "rawDate": "2001-12-03",

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1030,6 +1030,20 @@
         "href": "https://www.itu.int/rec/dologin_pub.asp?lang=e&id=T-REC-E.164-201011-I!!PDF-E&type=items",
         "date": "November 2010"
     },
+    "EBNF-NOTATION": {
+      "authors": [
+          "Tim Bray",
+          "Jean Paoli",
+          "Michael Sperberg-McQueen",
+          "Eve Maler",
+          "François Yergeau"
+      ],
+      "etAl": true,
+      "href": "https://www.w3.org/TR/xml/#sec-notation",
+      "title": "EBNF Notation",
+      "status": "REC",
+      "publisher": "W3C"
+    },
     "EBU-TT": {
         "title": "EBU TECH 3350: \"EBU-TT Subtitling format definition\"",
         "href": "https://tech.ebu.ch/docs/tech/tech3350.pdf",

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2529,7 +2529,7 @@
       "publisher": "OASIS"
     },
     "RELAXNG-COMPACT": {
-      "editors": ["James Clark"],
+      "authors": ["James Clark"],
       "href": "http://www.oasis-open.org/committees/relax-ng/compact-20021121.html",
       "title": "RELAX NG Compact Syntax",
       "rawDate": "2002-11-21",


### PR DESCRIPTION
The RDF-star WG will update virtually every RDF and SPARQL specification. Currently, there are a number of citations which are not in spec ref:

* Add reference to 1998 Design Note by TimBL on what RDF is and is not, referenced from rdf-schema
* Add rdf11-schema as an alias of rdf-schema.
* Add EBNF-NOTATION as a section reference into "xml", which is widely used in various RDF specifications.
* Add RDF11-XML as alias of rdf-syntax-grammar. Used in rdf11-concepts.
* Adds RELAXNG and RELAXNG-COMPACT, used by rdf-syntax-grammar.
