### PR TITLE
Fix broken markup for MOZ-ICONS entry

### DIFF
--- a/refs/legacy.json
+++ b/refs/legacy.json
@@ -36,7 +36,7 @@
     "MFREL": "<cite><a href=\"http://microformats.org/wiki/existing-rel-values#HTML5_link_type_extensions\">Microformats Wiki: existing rel values</a></cite>. Microformats.",
     "MICROFORMATS": "<a href='http://microformats.org'><cite>Microformats</cite></a>. URL: <a href='http://microformats.org'>http://microformats.org</a> ",
     "MNG": "<cite><a href=\"http://www.libpng.org/pub/mng/spec/\">MNG (Multiple-image Network Graphics) Format</a></cite>. G. Randers-Pehrson.",
-    "MOZ-ICONS": "Martin, J. Raskin, A. Gelman, L. Rood, D. Surman, M. Hadfield, G. Greant, Z. <a href = 'https://wiki.mozilla.org/Drumbeat/Challenges/Privacy_Icons'<cite>Privacy Icons</cite></a> 6 March 2010. Mozilla Wiki. URL: https://wiki.mozilla.org/Drumbeat/Challenges/Privacy_Icons ",
+    "MOZ-ICONS": "Martin, J. Raskin, A. Gelman, L. Rood, D. Surman, M. Hadfield, G. Greant, Z. <a href=\"https://wiki.mozilla.org/Drumbeat/Challenges/Privacy_Icons\"><cite>Privacy Icons</cite></a> 6 March 2010. Mozilla Wiki. URL: https://wiki.mozilla.org/Drumbeat/Challenges/Privacy_Icons ",
     "MPEG2": "<cite>ISO/IEC 13818-1: Information technology — Generic coding of moving pictures and associated audio information: Systems</cite>. ISO/IEC.",
     "MPEG4": "<cite>ISO/IEC 14496-12: ISO base media file format</cite>. ISO/IEC.",
     "MRCPv2": "Burnett, D. Shanmugham, S. <a href = 'https://tools.ietf.org/html/draft-ietf-speechsc-mrcpv2-27'><cite>Media Resource Control Protocol Version 2</cite></a> 15 November 2011. URL: <a href=\"https://tools.ietf.org/html/draft-ietf-speechsc-mrcpv2-27\">https://tools.ietf.org/html/draft-ietf-speechsc-mrcpv2-27</a>",


### PR DESCRIPTION
The `<a>` start tag wasn't closed. I slightly normalized the markup to match surrounding entries too. No text changes.