### PR TITLE
Add "status" field to FIPS refs.

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1382,31 +1382,36 @@
         "title": "FIPS PUB 180-3: Secure Hash Standard (SHS)",
         "date": "October 2008",
         "href": "https://csrc.nist.gov/publications/fips/fips180-3/fips180-3_final.pdf",
-        "publisher": "U.S. Department of Commerce/National Institute of Standards and Technology"
+        "publisher": "U.S. Department of Commerce/National Institute of Standards and Technology",
+        "status": "National Standard"
     },
     "FIPS-180-4": {
         "title": "FIPS PUB 180-4: Secure Hash Standard (SHS)",
         "date": "August 2015",
         "href": "https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf",
-        "publisher": "U.S. Department of Commerce/National Institute of Standards and Technology"
+        "publisher": "U.S. Department of Commerce/National Institute of Standards and Technology",
+        "status": "National Standard"
     },
     "FIPS-186-3": {
         "title": "FIPS PUB 186-3: Digital Signature Standard (DSS)",
         "date": "June 2009",
         "href": "https://csrc.nist.gov/publications/fips/fips186-3/fips_186-3.pdf",
-        "publisher": "U.S. Department of Commerce/National Institute of Standards and Technology"
+        "publisher": "U.S. Department of Commerce/National Institute of Standards and Technology",
+        "status": "National Standard"
     },
     "FIPS-186-4": {
         "title": "FIPS PUB 186-4: Digital Signature Standard (DSS)",
         "date": "July 2013",
         "href": "https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf",
-        "publisher": "U.S. Department of Commerce/National Institute of Standards and Technology"
+        "publisher": "U.S. Department of Commerce/National Institute of Standards and Technology",
+        "status": "National Standard"
     },
     "FIPS-186-5": {
         "title": "FIPS PUB 186-5: Digital Signature Standard (DSS)",
         "date": "3 February 2023",
         "href": "https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf",
-        "publisher": "U.S. Department of Commerce/National Institute of Standards and Technology"
+        "publisher": "U.S. Department of Commerce/National Institute of Standards and Technology",
+        "status": "National Standard"
     },
     "FIRESHEEP": {
         "authors": [


### PR DESCRIPTION
- Add "status" field to FIPS refs. Use "National Standard".
- Looking at the current status fields, i think "National Standard" is acceptable?  It aligns with "International Standard".
```
cat refs/biblio.json | jq '.[].status' | sort  | uniq -c | sort -n | less
```
- The intent is to replace a local respec local biblio entry that already used "National Standard":
https://github.com/w3c/vc-di-ecdsa/blob/cb24dba270d3a5f8b52d200d953937b702322599/index.html#L108