### PR TITLE
Add browser-specs as new source of specs

### DIFF
--- a/refs/browser-specs.json
+++ b/refs/browser-specs.json
@@ -1,0 +1,1870 @@
+{
+    "ANCHORS": {
+        "href": "https://immersive-web.github.io/anchors/",
+        "title": "WebXR Anchors Module",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/immersive-web/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/immersive-web/anchors"
+    },
+    "ANGLE_INSTANCED_ARRAYS": {
+        "href": "https://registry.khronos.org/webgl/extensions/ANGLE_instanced_arrays/",
+        "title": "WebGL ANGLE_instanced_arrays Khronos Ratified Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "ATTRIBUTION-REPORTING-API": {
+        "href": "https://wicg.github.io/attribution-reporting-api/",
+        "title": "Attribution Reporting",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/attribution-reporting-api"
+    },
+    "CAPABILITY-DELEGATION": {
+        "href": "https://wicg.github.io/capability-delegation/spec.html",
+        "title": "Capability Delegation",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/capability-delegation"
+    },
+    "CAPTURED-MOUSE-EVENTS": {
+        "href": "https://screen-share.github.io/captured-mouse-events/",
+        "title": "Captured Mouse Events",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/sccg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/screen-share/captured-mouse-events"
+    },
+    "CLIENT-HINT-RELIABILITY": {
+        "href": "https://datatracker.ietf.org/doc/html/draft-davidben-http-client-hint-reliability",
+        "title": "Client Hint Reliability",
+        "status": "Editor's Draft",
+        "publisher": "IETF",
+        "deliveredBy": [
+            "https://datatracker.ietf.org/wg/httpbis/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/davidben/http-client-hint-reliability"
+    },
+    "CLOSE-WATCHER": {
+        "href": "https://wicg.github.io/close-watcher/",
+        "title": "Close Watcher API",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/close-watcher"
+    },
+    "COMPOSITING-2": {
+        "href": "https://drafts.fxtf.org/compositing-2/",
+        "title": "Compositing and Blending Level 2",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/fxtf-drafts"
+    },
+    "CONTENT-INDEX": {
+        "href": "https://wicg.github.io/content-index/spec/",
+        "title": "Content Index",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/content-index"
+    },
+    "CONTENTEDITABLE": {
+        "href": "https://w3c.github.io/contentEditable/",
+        "title": "ContentEditable",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/groups/wg/webediting/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/contentEditable"
+    },
+    "CRASH-REPORTING": {
+        "href": "https://wicg.github.io/crash-reporting/",
+        "title": "Crash Reporting",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/crash-reporting"
+    },
+    "CSP-NEXT": {
+        "href": "https://wicg.github.io/csp-next/scripting-policy.html",
+        "title": "Scripting Policy",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/csp-next"
+    },
+    "CSS-COLOR-6": {
+        "href": "https://drafts.csswg.org/css-color-6/",
+        "title": "CSS Color Module Level 6",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CSS-COLOR-HDR": {
+        "href": "https://drafts.csswg.org/css-color-hdr/",
+        "title": "CSS Color HDR Module Level 1",
+        "status": "Unofficial Proposal Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CSS-CONDITIONAL-VALUES-1": {
+        "href": "https://drafts.csswg.org/css-conditional-values-1/",
+        "title": "CSS Conditional Values Module Level 1",
+        "status": "Unofficial Proposal Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CSS-DISPLAY-4": {
+        "href": "https://drafts.csswg.org/css-display-4/",
+        "title": "CSS Display Module Level 4",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CSS-EASING-2": {
+        "href": "https://drafts.csswg.org/css-easing-2/",
+        "title": "CSS Easing Functions Level 2",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CSS-ENV-1": {
+        "href": "https://drafts.csswg.org/css-env-1/",
+        "title": "CSS Environment Variables Module Level 1",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CSS-EXTENSIONS-1": {
+        "href": "https://drafts.csswg.org/css-extensions-1/",
+        "title": "CSS Extensions",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CSS-FORMS-1": {
+        "href": "https://drafts.csswg.org/css-forms-1/",
+        "title": "CSS Form Styling Module Level 1",
+        "status": "A Collection of Interesting Ideas",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CSS-GCPM-4": {
+        "href": "https://drafts.csswg.org/css-gcpm-4/",
+        "title": "CSS Generated Content for Paged Media Module Level 4",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CSS-GRID-3": {
+        "href": "https://drafts.csswg.org/css-grid-3/",
+        "title": "CSS Grid Layout Module Level 3",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CSS-IMAGES-5": {
+        "href": "https://drafts.csswg.org/css-images-5/",
+        "title": "CSS Images Module Level 5",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CSS-LINK-PARAMS-1": {
+        "href": "https://drafts.csswg.org/css-link-params-1/",
+        "title": "CSS Linked Parameters",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CSS-MULTICOL-2": {
+        "href": "https://drafts.csswg.org/css-multicol-2/",
+        "title": "CSS Multi-column Layout Module Level 2",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CSS-PAGE-4": {
+        "href": "https://drafts.csswg.org/css-page-4/",
+        "title": "Proposals for the future of CSS Paged Media",
+        "status": "Unofficial Proposal Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CSS-POSITION-4": {
+        "href": "https://drafts.csswg.org/css-position-4/",
+        "title": "CSS Positioned Layout Module Level 4",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CSS-SCROLL-SNAP-2": {
+        "href": "https://drafts.csswg.org/css-scroll-snap-2/",
+        "title": "CSS Scroll Snap Module Level 2",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CSS-SHAPES-2": {
+        "href": "https://drafts.csswg.org/css-shapes-2/",
+        "title": "CSS Shapes Module Level 2",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CSS-SIZE-ADJUST-1": {
+        "href": "https://drafts.csswg.org/css-size-adjust-1/",
+        "title": "CSS Mobile Text Size Adjustment Module Level 1",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CSS-TRANSITIONS-2": {
+        "href": "https://drafts.csswg.org/css-transitions-2/",
+        "title": "CSS Transitions Level 2",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CSS-TYPED-OM-2": {
+        "href": "https://drafts.css-houdini.org/css-typed-om-2/",
+        "title": "CSS Typed OM Level 2",
+        "status": "A Collection of Interesting Ideas",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/css-houdini-drafts"
+    },
+    "CSS-VALUES-5": {
+        "href": "https://drafts.csswg.org/css-values-5/",
+        "title": "CSS Values and Units Module Level 5",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CSS-VARIABLES-2": {
+        "href": "https://drafts.csswg.org/css-variables-2/",
+        "title": "CSS Custom Properties for Cascading Variables Module Level 2",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CSS-VIEWPORT": {
+        "href": "https://drafts.csswg.org/css-viewport/",
+        "title": "CSS Viewport Module Level 1",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/csswg-drafts"
+    },
+    "CUSTOM-STATE-PSEUDO-CLASS": {
+        "href": "https://wicg.github.io/custom-state-pseudo-class/",
+        "title": "Custom State Pseudo Class",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/custom-state-pseudo-class"
+    },
+    "DATACUE": {
+        "href": "https://wicg.github.io/datacue/",
+        "title": "DataCue API",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/datacue"
+    },
+    "DEPRECATION-REPORTING": {
+        "href": "https://wicg.github.io/deprecation-reporting/",
+        "title": "Deprecation Reporting",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/deprecation-reporting"
+    },
+    "DIGEST-HEADERS": {
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers",
+        "title": "Digest Fields",
+        "status": "Editor's Draft",
+        "publisher": "IETF",
+        "deliveredBy": [
+            "https://datatracker.ietf.org/wg/httpbis/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/httpwg/http-extensions"
+    },
+    "DIGITAL-GOODS": {
+        "href": "https://wicg.github.io/digital-goods/",
+        "title": "Digital Goods API",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/digital-goods"
+    },
+    "DIRECT-SOCKETS": {
+        "href": "https://wicg.github.io/direct-sockets/",
+        "title": "Direct Sockets API",
+        "status": "Unofficial Proposal Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/direct-sockets"
+    },
+    "DOCUMENT-PICTURE-IN-PICTURE": {
+        "href": "https://wicg.github.io/document-picture-in-picture/",
+        "title": "Document Picture-in-Picture Specification",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/document-picture-in-picture"
+    },
+    "ELEMENT-CAPTURE": {
+        "href": "https://screen-share.github.io/element-capture/",
+        "title": "Element Capture",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/sccg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/screen-share/element-capture"
+    },
+    "EXT_BLEND_MINMAX": {
+        "href": "https://registry.khronos.org/webgl/extensions/EXT_blend_minmax/",
+        "title": "WebGL EXT_blend_minmax Khronos Ratified Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "EXT_COLOR_BUFFER_FLOAT": {
+        "href": "https://registry.khronos.org/webgl/extensions/EXT_color_buffer_float/",
+        "title": "WebGL EXT_color_buffer_float Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "EXT_COLOR_BUFFER_HALF_FLOAT": {
+        "href": "https://registry.khronos.org/webgl/extensions/EXT_color_buffer_half_float/",
+        "title": "WebGL EXT_color_buffer_half_float Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "EXT_DISJOINT_TIMER_QUERY": {
+        "href": "https://registry.khronos.org/webgl/extensions/EXT_disjoint_timer_query/",
+        "title": "WebGL EXT_disjoint_timer_query Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "EXT_DISJOINT_TIMER_QUERY_WEBGL2": {
+        "href": "https://registry.khronos.org/webgl/extensions/EXT_disjoint_timer_query_webgl2/",
+        "title": "WebGL EXT_disjoint_timer_query_webgl2 Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "EXT_FLOAT_BLEND": {
+        "href": "https://registry.khronos.org/webgl/extensions/EXT_float_blend/",
+        "title": "WebGL EXT_float_blend Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "EXT_FRAG_DEPTH": {
+        "href": "https://registry.khronos.org/webgl/extensions/EXT_frag_depth/",
+        "title": "WebGL EXT_frag_depth Khronos Ratified Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "EXT_SHADER_TEXTURE_LOD": {
+        "href": "https://registry.khronos.org/webgl/extensions/EXT_shader_texture_lod/",
+        "title": "WebGL EXT_shader_texture_lod Khronos Ratified Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "EXT_SRGB": {
+        "href": "https://registry.khronos.org/webgl/extensions/EXT_sRGB/",
+        "title": "WebGL EXT_sRGB Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "EXT_TEXTURE_COMPRESSION_BPTC": {
+        "href": "https://registry.khronos.org/webgl/extensions/EXT_texture_compression_bptc/",
+        "title": "WebGL EXT_texture_compression_bptc Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "EXT_TEXTURE_COMPRESSION_RGTC": {
+        "href": "https://registry.khronos.org/webgl/extensions/EXT_texture_compression_rgtc/",
+        "title": "WebGL EXT_texture_compression_rgtc Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "EXT_TEXTURE_FILTER_ANISOTROPIC": {
+        "href": "https://registry.khronos.org/webgl/extensions/EXT_texture_filter_anisotropic/",
+        "title": "WebGL EXT_texture_filter_anisotropic Khronos Ratified Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "EXT_TEXTURE_NORM16": {
+        "href": "https://registry.khronos.org/webgl/extensions/EXT_texture_norm16/",
+        "title": "WebGL EXT_texture_norm16 Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "EYEDROPPER-API": {
+        "href": "https://wicg.github.io/eyedropper-api/",
+        "title": "EyeDropper API",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/eyedropper-api"
+    },
+    "FEDCM": {
+        "href": "https://fedidcg.github.io/FedCM/",
+        "title": "Federated Credential Management API",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/fedidcg/FedCM"
+    },
+    "FENCED-FRAME": {
+        "href": "https://wicg.github.io/fenced-frame/",
+        "title": "Fenced Frame",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/fenced-frame"
+    },
+    "FIDO-V2.1": {
+        "href": "https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html",
+        "title": "Client to Authenticator Protocol (CTAP)",
+        "status": "Editor's Draft",
+        "publisher": "FIDO Alliance",
+        "deliveredBy": [
+            "https://fidoalliance.org/members/working-groups/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json"
+    },
+    "FILTER-EFFECTS-2": {
+        "href": "https://drafts.fxtf.org/filter-effects-2/",
+        "title": "Filter Effects Module Level 2",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/fxtf-drafts"
+    },
+    "FIRST-PARTY-SETS": {
+        "href": "https://wicg.github.io/first-party-sets/",
+        "title": "User Agent Interaction with First-Party Sets",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/first-party-sets"
+    },
+    "FONT-METRICS-API-1": {
+        "href": "https://drafts.css-houdini.org/font-metrics-api-1/",
+        "title": "Font Metrics API Level 1",
+        "status": "A Collection of Interesting Ideas",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Style/CSS/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/css-houdini-drafts"
+    },
+    "GAMEPAD-EXTENSIONS": {
+        "href": "https://w3c.github.io/gamepad/extensions.html",
+        "title": "Gamepad Extensions",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/groups/wg/webapps/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/gamepad"
+    },
+    "GET-INSTALLED-RELATED-APPS": {
+        "href": "https://wicg.github.io/get-installed-related-apps/spec/",
+        "title": "Get Installed Related Apps API",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/get-installed-related-apps"
+    },
+    "GPC-SPEC": {
+        "href": "https://privacycg.github.io/gpc-spec/",
+        "title": "Global Privacy Control (GPC)",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/privacycg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/privacycg/gpc-spec"
+    },
+    "INK-ENHANCEMENT": {
+        "href": "https://wicg.github.io/ink-enhancement/",
+        "title": "Ink API",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/ink-enhancement"
+    },
+    "INTERVENTION-REPORTING": {
+        "href": "https://wicg.github.io/intervention-reporting/",
+        "title": "Intervention Reporting",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/intervention-reporting"
+    },
+    "IS-INPUT-PENDING": {
+        "href": "https://wicg.github.io/is-input-pending/",
+        "title": "isInputPending",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/is-input-pending"
+    },
+    "KHR_PARALLEL_SHADER_COMPILE": {
+        "href": "https://registry.khronos.org/webgl/extensions/KHR_parallel_shader_compile/",
+        "title": "WebGL KHR_parallel_shader_compile Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "MATHML-AAM": {
+        "href": "https://w3c.github.io/mathml-aam/",
+        "title": "MathML Accessiblity API Mappings 1.0",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/WAI/ARIA/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/mathml-aam"
+    },
+    "MEDIA-FEEDS": {
+        "href": "https://wicg.github.io/media-feeds/",
+        "title": "Media Feeds",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/media-feeds"
+    },
+    "MEDIACAPTURE-AUTOMATION": {
+        "href": "https://w3c.github.io/mediacapture-automation/",
+        "title": "Media Capture Automation",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/groups/wg/webrtc/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/mediacapture-automation"
+    },
+    "MEDIACAPTURE-HANDLE-ACTIONS": {
+        "href": "https://w3c.github.io/mediacapture-handle/actions/",
+        "title": "The Capture-Handle Actions Mechanism",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/groups/wg/webrtc/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/mediacapture-handle"
+    },
+    "MODEL-ELEMENT": {
+        "href": "https://immersive-web.github.io/model-element/",
+        "title": "The <model> element",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/immersive-web/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/immersive-web/model-element"
+    },
+    "NAV-TRACKING-MITIGATIONS": {
+        "href": "https://privacycg.github.io/nav-tracking-mitigations/",
+        "title": "Navigational-Tracking Mitigations",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/privacycg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/privacycg/nav-tracking-mitigations"
+    },
+    "OES_DRAW_BUFFERS_INDEXED": {
+        "href": "https://registry.khronos.org/webgl/extensions/OES_draw_buffers_indexed/",
+        "title": "WebGL OES_draw_buffers_indexed Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "OES_ELEMENT_INDEX_UINT": {
+        "href": "https://registry.khronos.org/webgl/extensions/OES_element_index_uint/",
+        "title": "WebGL OES_element_index_uint Khronos Ratified Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "OES_FBO_RENDER_MIPMAP": {
+        "href": "https://registry.khronos.org/webgl/extensions/OES_fbo_render_mipmap/",
+        "title": "WebGL OES_fbo_render_mipmap Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "OES_STANDARD_DERIVATIVES": {
+        "href": "https://registry.khronos.org/webgl/extensions/OES_standard_derivatives/",
+        "title": "WebGL OES_standard_derivatives Khronos Ratified Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "OES_TEXTURE_FLOAT": {
+        "href": "https://registry.khronos.org/webgl/extensions/OES_texture_float/",
+        "title": "WebGL OES_texture_float Khronos Ratified Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "OES_TEXTURE_FLOAT_LINEAR": {
+        "href": "https://registry.khronos.org/webgl/extensions/OES_texture_float_linear/",
+        "title": "WebGL OES_texture_float_linear Khronos Ratified Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "OES_TEXTURE_HALF_FLOAT": {
+        "href": "https://registry.khronos.org/webgl/extensions/OES_texture_half_float/",
+        "title": "WebGL OES_texture_half_float Khronos Ratified Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "OES_TEXTURE_HALF_FLOAT_LINEAR": {
+        "href": "https://registry.khronos.org/webgl/extensions/OES_texture_half_float_linear/",
+        "title": "WebGL OES_texture_half_float_linear Khronos Ratified Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "OES_VERTEX_ARRAY_OBJECT": {
+        "href": "https://registry.khronos.org/webgl/extensions/OES_vertex_array_object/",
+        "title": "WebGL OES_vertex_array_object Khronos Ratified Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "OVERSCROLL-SCROLLEND-EVENTS": {
+        "href": "https://wicg.github.io/overscroll-scrollend-events/",
+        "title": "overscroll and scrollend events",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/overscroll-scrollend-events"
+    },
+    "OVR_MULTIVIEW2": {
+        "href": "https://registry.khronos.org/webgl/extensions/OVR_multiview2/",
+        "title": "WebGL OVR_multiview2 Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "PARTITIONED-COOKIES": {
+        "href": "https://datatracker.ietf.org/doc/html/draft-cutler-httpbis-partitioned-cookies",
+        "title": "Cookies Having Independent Partitioned State specification",
+        "status": "Editor's Draft",
+        "publisher": "IETF",
+        "deliveredBy": [
+            "https://datatracker.ietf.org/wg/httpbis/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/DCtheTall/CHIPS-spec"
+    },
+    "PERFORMANCE-MEASURE-MEMORY": {
+        "href": "https://wicg.github.io/performance-measure-memory/",
+        "title": "Measure Memory API",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/performance-measure-memory"
+    },
+    "PORTALS": {
+        "href": "https://wicg.github.io/portals/",
+        "title": "Portals",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/portals"
+    },
+    "PREFETCH": {
+        "href": "https://wicg.github.io/nav-speculation/prefetch.html",
+        "title": "Prefetch",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/nav-speculation"
+    },
+    "PRERENDERING-REVAMPED": {
+        "href": "https://wicg.github.io/nav-speculation/prerendering.html",
+        "title": "Prerendering Revamped",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/nav-speculation"
+    },
+    "PRIVATE-CLICK-MEASUREMENT": {
+        "href": "https://privacycg.github.io/private-click-measurement/",
+        "title": "Private Click Measurement",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/privacycg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/privacycg/private-click-measurement"
+    },
+    "PRIVATE-NETWORK-ACCESS": {
+        "href": "https://wicg.github.io/private-network-access/",
+        "title": "Private Network Access",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/private-network-access"
+    },
+    "RAW-CAMERA-ACCESS": {
+        "href": "https://immersive-web.github.io/raw-camera-access/",
+        "title": "WebXR Raw Camera Access Module",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/immersive-web/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/immersive-web/raw-camera-access"
+    },
+    "REAL-WORLD-MESHING": {
+        "href": "https://immersive-web.github.io/real-world-meshing/",
+        "title": "WebXR Mesh Detection Module",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/immersive-web/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/immersive-web/real-world-meshing"
+    },
+    "REQUESTSTORAGEACCESSFOR": {
+        "href": "https://privacycg.github.io/requestStorageAccessFor/",
+        "title": "requestStorageAccessFor API",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/privacycg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/privacycg/requestStorageAccessFor"
+    },
+    "RESPONSIVE-IMAGE-CLIENT-HINTS": {
+        "href": "https://wicg.github.io/responsive-image-client-hints/",
+        "title": "Responsive Image Client Hints",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/responsive-image-client-hints"
+    },
+    "RFC6265BIS": {
+        "href": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis",
+        "title": "Cookies: HTTP State Management Mechanism",
+        "status": "Editor's Draft",
+        "publisher": "IETF",
+        "deliveredBy": [
+            "https://datatracker.ietf.org/wg/httpbis/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/httpwg/http-extensions"
+    },
+    "SANITIZER-API": {
+        "href": "https://wicg.github.io/sanitizer-api/",
+        "title": "HTML Sanitizer API",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/sanitizer-api"
+    },
+    "SAVEDATA": {
+        "href": "https://wicg.github.io/savedata/",
+        "title": "Save Data API",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/savedata"
+    },
+    "SCROLL-TO-TEXT-FRAGMENT": {
+        "href": "https://wicg.github.io/scroll-to-text-fragment/",
+        "title": "URL Fragment Text Directives",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/scroll-to-text-fragment"
+    },
+    "SERIAL": {
+        "href": "https://wicg.github.io/serial/",
+        "title": "Web Serial API",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/serial"
+    },
+    "SHARED-STORAGE": {
+        "href": "https://wicg.github.io/shared-storage/",
+        "title": "Shared Storage API",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/shared-storage"
+    },
+    "SOURCEMAP": {
+        "href": "https://sourcemaps.info/spec.html",
+        "title": "Source Map Revision 3 Proposal",
+        "status": "Editor's Draft",
+        "publisher": "sourcemaps.info",
+        "deliveredBy": [
+            "https://sourcemaps.info/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json"
+    },
+    "SPARQL12-CONCEPTS": {
+        "href": "https://w3c.github.io/sparql-concepts/spec/",
+        "title": "SPARQL 1.2 Overview",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/groups/wg/rdf-star/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/sparql-concepts"
+    },
+    "SPECULATION-RULES": {
+        "href": "https://wicg.github.io/nav-speculation/speculation-rules.html",
+        "title": "Speculation Rules",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/nav-speculation"
+    },
+    "STORAGE-ACCESS": {
+        "href": "https://privacycg.github.io/storage-access/",
+        "title": "The Storage Access API",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/privacycg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/privacycg/storage-access"
+    },
+    "STORAGE-BUCKETS": {
+        "href": "https://wicg.github.io/storage-buckets/",
+        "title": "Storage Buckets API",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/storage-buckets"
+    },
+    "SVG-ANIMATIONS": {
+        "href": "https://svgwg.org/specs/animations/",
+        "title": "SVG Animations Level 2",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/Graphics/SVG/WG/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/svgwg"
+    },
+    "TC39-ARRAY-FIND-FROM-LAST": {
+        "href": "https://tc39.es/proposal-array-find-from-last/",
+        "title": "Proposal-array-find-from-last",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-array-find-from-last"
+    },
+    "TC39-ARRAY-FROM-ASYNC": {
+        "href": "https://tc39.es/proposal-array-from-async/",
+        "title": "ES Array.fromAsync (2022)",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-array-from-async"
+    },
+    "TC39-ARRAY-GROUPING": {
+        "href": "https://tc39.es/proposal-array-grouping/",
+        "title": "Array Grouping",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-array-grouping"
+    },
+    "TC39-ARRAYBUFFER-TRANSFER": {
+        "href": "https://tc39.es/proposal-arraybuffer-transfer/",
+        "title": "ArrayBuffer transfer",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-arraybuffer-transfer"
+    },
+    "TC39-ASYNC-EXPLICIT-RESOURCE-MANAGEMENT": {
+        "href": "https://tc39.es/proposal-async-explicit-resource-management/",
+        "title": "ECMAScript Async Explicit Resource Management",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-async-explicit-resource-management"
+    },
+    "TC39-ATOMICS-WAIT-ASYNC": {
+        "href": "https://tc39.es/proposal-atomics-wait-async/",
+        "title": "Atomics.waitAsync",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-atomics-wait-async"
+    },
+    "TC39-CHANGE-ARRAY-BY-COPY": {
+        "href": "https://tc39.es/proposal-change-array-by-copy/",
+        "title": "Change Array by copy",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-change-array-by-copy"
+    },
+    "TC39-DECORATORS": {
+        "href": "https://tc39.es/proposal-decorators/",
+        "title": "Decorators proposal",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-decorators"
+    },
+    "TC39-EXPLICIT-RESOURCE-MANAGEMENT": {
+        "href": "https://tc39.es/proposal-explicit-resource-management/",
+        "title": "ECMAScript Explicit Resource Management",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-explicit-resource-management"
+    },
+    "TC39-FLOAT16ARRAY": {
+        "href": "https://tc39.es/proposal-float16array/",
+        "title": "Float16Array",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-float16array"
+    },
+    "TC39-INTL-ANNEXES": {
+        "href": "https://tc39.es/proposal-intl-numberformat-v3/out/annexes/proposed.html",
+        "title": "Intl Annexes",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-intl-numberformat-v3"
+    },
+    "TC39-INTL-DURATION-FORMAT": {
+        "href": "https://tc39.es/proposal-intl-duration-format/",
+        "title": "Intl.DurationFormat",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-intl-duration-format"
+    },
+    "TC39-INTL-ENUMERATION": {
+        "href": "https://tc39.es/proposal-intl-enumeration/",
+        "title": "Intl Enumeration API Specification",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-intl-enumeration"
+    },
+    "TC39-INTL-EXTEND-TIMEZONENAME": {
+        "href": "https://tc39.es/proposal-intl-extend-timezonename/",
+        "title": "Extend TimeZoneName Option Proposal",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-intl-extend-timezonename"
+    },
+    "TC39-INTL-LOCALE-INFO": {
+        "href": "https://tc39.es/proposal-intl-locale-info/",
+        "title": "Intl Locale Info Proposal",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-intl-locale-info"
+    },
+    "TC39-INTL-NEGOTIATION": {
+        "href": "https://tc39.es/proposal-intl-numberformat-v3/out/negotiation/proposed.html",
+        "title": "Intl Parameter Resolution",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-intl-numberformat-v3"
+    },
+    "TC39-INTL-NUMBERFORMAT": {
+        "href": "https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/proposed.html",
+        "title": "Intl.NumberFormat",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-intl-numberformat-v3"
+    },
+    "TC39-INTL-PLURALRULES": {
+        "href": "https://tc39.es/proposal-intl-numberformat-v3/out/pluralrules/proposed.html",
+        "title": "Intl.PluralRules",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-intl-numberformat-v3"
+    },
+    "TC39-IS-USV-STRING": {
+        "href": "https://tc39.es/proposal-is-usv-string/",
+        "title": "Well-Formed Unicode Strings",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-is-usv-string"
+    },
+    "TC39-ITERATOR-HELPERS": {
+        "href": "https://tc39.es/proposal-iterator-helpers/",
+        "title": "Iterator Helpers",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-iterator-helpers"
+    },
+    "TC39-JSON-MODULES": {
+        "href": "https://tc39.es/proposal-json-modules/",
+        "title": "JSON modules",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-json-modules"
+    },
+    "TC39-JSON-PARSE-WITH-SOURCE": {
+        "href": "https://tc39.es/proposal-json-parse-with-source/",
+        "title": "JSON.parse source text access",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-json-parse-with-source"
+    },
+    "TC39-REGEXP-MODIFIERS": {
+        "href": "https://tc39.es/proposal-regexp-modifiers/",
+        "title": "Regular Expression Pattern Modifiers for ECMAScript",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-regexp-modifiers"
+    },
+    "TC39-RESIZABLEARRAYBUFFER": {
+        "href": "https://tc39.es/proposal-resizablearraybuffer/",
+        "title": "Resizable ArrayBuffer and growable SharedArrayBuffer",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-resizablearraybuffer"
+    },
+    "TC39-SET-METHODS": {
+        "href": "https://tc39.es/proposal-set-methods/",
+        "title": "Set methods",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-set-methods"
+    },
+    "TC39-SHADOWREALM": {
+        "href": "https://tc39.es/proposal-shadowrealm/",
+        "title": "ShadowRealm API",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-shadowrealm"
+    },
+    "TC39-SYMBOLS-AS-WEAKMAP-KEYS": {
+        "href": "https://tc39.es/proposal-symbols-as-weakmap-keys/",
+        "title": "Symbol as WeakMap Keys Proposal",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-symbols-as-weakmap-keys"
+    },
+    "TC39-TEMPORAL": {
+        "href": "https://tc39.es/proposal-temporal/",
+        "title": "Temporal proposal",
+        "status": "Editor's Draft",
+        "publisher": "Ecma International",
+        "deliveredBy": [
+            "https://tc39.es/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/tc39/proposal-temporal"
+    },
+    "TRUST-TOKEN-API": {
+        "href": "https://wicg.github.io/trust-token-api/",
+        "title": "Private State Token API",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/trust-token-api"
+    },
+    "TURTLEDOVE": {
+        "href": "https://wicg.github.io/turtledove/",
+        "title": "Protected Audience (formerly FLEDGE)",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/turtledove"
+    },
+    "UA-CLIENT-HINTS": {
+        "href": "https://wicg.github.io/ua-client-hints/",
+        "title": "User-Agent Client Hints",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/ua-client-hints"
+    },
+    "URLPATTERN": {
+        "href": "https://wicg.github.io/urlpattern/",
+        "title": "URLPattern API",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/urlpattern"
+    },
+    "USER-PREFERENCE-MEDIA-FEATURES-HEADERS": {
+        "href": "https://wicg.github.io/user-preference-media-features-headers/",
+        "title": "User Preference Media Features Client Hints Headers",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/user-preference-media-features-headers"
+    },
+    "VIDEO-RVFC": {
+        "href": "https://wicg.github.io/video-rvfc/",
+        "title": "HTMLVideoElement.requestVideoFrameCallback()",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/video-rvfc"
+    },
+    "WASM-JS-API-2-FORK-EXCEPTION-HANDLING": {
+        "href": "https://webassembly.github.io/exception-handling/js-api/",
+        "title": "WebAssembly JavaScript Interface: Exception Handling",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/webassembly/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WebAssembly/exception-handling"
+    },
+    "WEB-OTP": {
+        "href": "https://wicg.github.io/web-otp/",
+        "title": "WebOTP API",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/web-otp"
+    },
+    "WEBCRYPTO-SECURE-CURVES": {
+        "href": "https://wicg.github.io/webcrypto-secure-curves/",
+        "title": "Secure Curves in the Web Cryptography API",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/webcrypto-secure-curves"
+    },
+    "WEBGL1": {
+        "href": "https://registry.khronos.org/webgl/specs/latest/1.0/",
+        "title": "WebGL Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "WEBGL2": {
+        "href": "https://registry.khronos.org/webgl/specs/latest/2.0/",
+        "title": "WebGL 2.0 Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "WEBGL_BLEND_EQUATION_ADVANCED_COHERENT": {
+        "href": "https://registry.khronos.org/webgl/extensions/WEBGL_blend_equation_advanced_coherent/",
+        "title": "WebGL WEBGL_blend_equation_advanced_coherent Extension Draft Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "WEBGL_CLIP_CULL_DISTANCE": {
+        "href": "https://registry.khronos.org/webgl/extensions/WEBGL_clip_cull_distance/",
+        "title": "WebGL WEBGL_clip_cull_distance Extension Draft Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "WEBGL_COLOR_BUFFER_FLOAT": {
+        "href": "https://registry.khronos.org/webgl/extensions/WEBGL_color_buffer_float/",
+        "title": "WebGL WEBGL_color_buffer_float Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "WEBGL_COMPRESSED_TEXTURE_ASTC": {
+        "href": "https://registry.khronos.org/webgl/extensions/WEBGL_compressed_texture_astc/",
+        "title": "WebGL WEBGL_compressed_texture_astc Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "WEBGL_COMPRESSED_TEXTURE_ETC": {
+        "href": "https://registry.khronos.org/webgl/extensions/WEBGL_compressed_texture_etc/",
+        "title": "WebGL WEBGL_compressed_texture_etc Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "WEBGL_COMPRESSED_TEXTURE_ETC1": {
+        "href": "https://registry.khronos.org/webgl/extensions/WEBGL_compressed_texture_etc1/",
+        "title": "WebGL WEBGL_compressed_texture_etc1 Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "WEBGL_COMPRESSED_TEXTURE_PVRTC": {
+        "href": "https://registry.khronos.org/webgl/extensions/WEBGL_compressed_texture_pvrtc/",
+        "title": "WebGL WEBGL_compressed_texture_pvrtc Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "WEBGL_COMPRESSED_TEXTURE_S3TC": {
+        "href": "https://registry.khronos.org/webgl/extensions/WEBGL_compressed_texture_s3tc/",
+        "title": "WebGL WEBGL_compressed_texture_s3tc Khronos Ratified Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "WEBGL_COMPRESSED_TEXTURE_S3TC_SRGB": {
+        "href": "https://registry.khronos.org/webgl/extensions/WEBGL_compressed_texture_s3tc_srgb/",
+        "title": "WebGL WEBGL_compressed_texture_s3tc_srgb Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "WEBGL_DEBUG_RENDERER_INFO": {
+        "href": "https://registry.khronos.org/webgl/extensions/WEBGL_debug_renderer_info/",
+        "title": "WebGL WEBGL_debug_renderer_info Khronos Ratified Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "WEBGL_DEBUG_SHADERS": {
+        "href": "https://registry.khronos.org/webgl/extensions/WEBGL_debug_shaders/",
+        "title": "WebGL WEBGL_debug_shaders Khronos Ratified Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "WEBGL_DEPTH_TEXTURE": {
+        "href": "https://registry.khronos.org/webgl/extensions/WEBGL_depth_texture/",
+        "title": "WebGL WEBGL_depth_texture Khronos Ratified Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "WEBGL_DRAW_BUFFERS": {
+        "href": "https://registry.khronos.org/webgl/extensions/WEBGL_draw_buffers/",
+        "title": "WebGL WEBGL_draw_buffers Khronos Ratified Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "WEBGL_DRAW_INSTANCED_BASE_VERTEX_BASE_INSTANCE": {
+        "href": "https://registry.khronos.org/webgl/extensions/WEBGL_draw_instanced_base_vertex_base_instance/",
+        "title": "WebGL WEBGL_draw_instanced_base_vertex_base_instance Extension Draft Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "WEBGL_LOSE_CONTEXT": {
+        "href": "https://registry.khronos.org/webgl/extensions/WEBGL_lose_context/",
+        "title": "WebGL WEBGL_lose_context Khronos Ratified Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "WEBGL_MULTI_DRAW": {
+        "href": "https://registry.khronos.org/webgl/extensions/WEBGL_multi_draw/",
+        "title": "WebGL WEBGL_multi_draw Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "WEBGL_MULTI_DRAW_INSTANCED_BASE_VERTEX_BASE_INSTANCE": {
+        "href": "https://registry.khronos.org/webgl/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/",
+        "title": "WebGL WEBGL_multi_draw_instanced_base_vertex_base_instance Extension Draft Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "WEBGL_PROVOKING_VERTEX": {
+        "href": "https://registry.khronos.org/webgl/extensions/WEBGL_provoking_vertex/",
+        "title": "WebGL WEBGL_provoking_vertex Extension Specification",
+        "status": "Editor's Draft",
+        "publisher": "Khronos Group",
+        "deliveredBy": [
+            "https://www.khronos.org/webgl/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/KhronosGroup/WebGL"
+    },
+    "WEBHID": {
+        "href": "https://wicg.github.io/webhid/",
+        "title": "WebHID API",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/webhid"
+    },
+    "WEBPACKAGE": {
+        "href": "https://wicg.github.io/webpackage/loading.html",
+        "title": "Loading Signed Exchanges",
+        "status": "Draft Community Group Report",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/community/wicg/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/WICG/webpackage"
+    },
+    "WEBRTC-ICE": {
+        "href": "https://w3c.github.io/webrtc-ice/",
+        "title": "IceTransport Extensions for WebRTC",
+        "status": "Editor's Draft",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/groups/wg/webrtc/"
+        ],
+        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
+        "repository": "https://github.com/w3c/webrtc-ice"
+    }
+}

--- a/scripts/browser-specs.js
+++ b/scripts/browser-specs.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+var request = require('request'),
+    userAgent = require("./user-agent"),
+    helper = require('./helper'),
+    bibref = require('../lib/bibref');
+
+var SOURCE = 'https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json';
+var PUBLISHER = 'browser-specs';
+var FILENAME = PUBLISHER.toLowerCase() + ".json";
+
+var biblio = helper.readBiblio();
+var current = helper.readBiblio(FILENAME);
+var updatedList = {};
+var refs = bibref.createUppercaseRefs(bibref.expandRefs(bibref.raw));
+
+function convertSpec(spec) {
+    const ref = {
+        href: spec.url,
+        title: spec.title,
+        status: spec.nightly.status,
+        publisher: spec.organization,
+        deliveredBy: spec.groups.map(function(group) {
+            // Specref does not like fragment IDs in group URLs
+            // (not a big deal, that would only potentially be useful for
+            // FIDO Alliance groups)
+            return group.url.replace(/#.*$/, '');
+        }),
+        source: SOURCE
+    };
+    if (spec.nightly.repository) {
+        ref.repository = spec.nightly.repository;
+    }
+    return ref;
+}
+
+
+console.log("Updating", PUBLISHER, "references...");
+console.log("Fetching", SOURCE + "...");
+request({
+    url: SOURCE,
+    headers: {
+        'User-Agent': userAgent()
+    }
+}, function(err, response, body) {
+    if (err || response.statusCode !== 200) {
+        console.log("Can't fetch", SOURCE + ".");
+        return;
+    }
+
+    console.log("Parsing", SOURCE + "...");
+    JSON.parse(body)
+        .filter(function(spec) {
+            // Only keep specs from browser-specs for which the info came from
+            // the spec itself (other specs should already be in Specref)
+            const uppercaseId = spec.shortname.toUpperCase();
+            return spec.source === 'spec';
+        })
+        .forEach(function(spec) {
+            ref = convertSpec(spec);
+            
+            var id = spec.shortname;
+            var uppercaseId = id.toUpperCase();
+
+            // Spec may already exist in Specref under another name
+            if (!current[uppercaseId]) {
+                var rv = bibref.reverseLookup([ref.href])[ref.href];
+                if (rv) {
+                    return;
+                }
+            }
+
+            if (!(uppercaseId in refs)) {
+                updatedList[uppercaseId] = ref;
+            } else {
+                var existingRef = refs[uppercaseId];
+                while (existingRef.aliasOf) { existingRef = refs[existingRef.aliasOf]; }
+                if (!("source" in existingRef) || existingRef.source == SOURCE ||
+                        bibref.normalizeUrl(ref.href) == bibref.normalizeUrl(existingRef.href)) {
+                    updatedList[uppercaseId] = ref;
+                } else {
+                    throw new Error("cannot override " + uppercaseId);
+                }
+            }
+        });
+    updatedList = helper.sortRefs(updatedList);
+    console.log("updating existing refs.")
+    helper.writeBiblio(FILENAME, updatedList);
+    helper.tryOverwrite(FILENAME);
+    helper.writeBiblio(biblio);
+});

--- a/scripts/run-all
+++ b/scripts/run-all
@@ -2,6 +2,7 @@
 
 node "./scripts/list-refs.js" &&
 node "./scripts/run.js" &&
+node "./scripts/browser-specs.js" &&
 node "./scripts/ietf.js" &&
 node "./scripts/w3c.js" &&
 node "./scripts/csswg.js" &&


### PR DESCRIPTION
The [w3c/browser-specs](https://github.com/w3c/browser-specs/) project contains a curated list of specifications that compose the web platform. Most of the info it contains comes from the W3C API (that info is already in Specref), and from Specref itself.

That said, the list also contains additional specs that are not in Specref. These are mostly "early" drafts developed in W3C community groups but not yet published as Working Drafts, and WebGL extension specs.

With this update, Specref now retrieves specs from browser-specs that it does not yet know anything about to fill a `browser-specs.json` file. This is useful for spec editors, because specs in browser-specs get crawled and ingested in the cross-reference database of terms used by Bikeshed and Respec, meaning that a spec editor can currently end up in a situation where they can reference a term defined in a spec and yet are unable to reference the spec itself. Currently, this affects 170 specs, which this update adds to Specref.

The script runs first in `run-all` to drop specs from `browser-specs.json` as soon as possible (removal from the browser-specs source should typically mean that the spec has started to appear in another source, and it's going to be better to rely on that other source directly).

The logic is based on `fetch-refs.js` with custom code to filter out specs that are already in Specref, and to delete former entries that no longer exist in browser-specs.

One question: the spec ID in browser-specs is lowercase. Code converts them to uppercase IDs for Specref. Or is it better to keep lowercase IDs along with the `createUppercaseRefs` aliasing logic?

I'm happy to maintain that code over time, as needed, e.g., if we realize that spec transitions to more authoritative sources (IETF, W3C, etc.) is not as smooth as it should be.

Via https://github.com/w3c/browser-specs/issues/975