### PR TITLE
Resume browser-specs source, preserving entries

### DIFF
--- a/scripts/browser-specs.js
+++ b/scripts/browser-specs.js
@@ -30,9 +30,26 @@ function convertSpec(spec) {
     if (spec.nightly.repository) {
         ref.repository = spec.nightly.repository;
     }
+    if (spec.standing === 'discontinued') {
+        ref.isRetired = true;
+    }
+    if (spec.obsoletedBy) {
+        ref.obsoletedBy = spec.obsoletedBy;
+    }
     return ref;
 }
 
+
+function isInSpecref(id) {
+    if (updatedList[id]) {
+        return true;
+    }
+    var ref = refs[id];
+    if (ref && ref.source !== SOURCE) {
+        return true;
+    }
+    return false;
+}
 
 console.log("Updating", PUBLISHER, "references...");
 console.log("Fetching", SOURCE + "...");
@@ -48,59 +65,110 @@ request({
     }
 
     console.log("Parsing", SOURCE + "...");
-    JSON.parse(body)
+    const browserSpecs = JSON.parse(body);
+    browserSpecs
         .filter(function(spec) {
-            // Only keep specs from browser-specs for which the info came from
-            // the spec itself (other specs should already be in Specref)
+            // Only keep specs from browser-specs that meet the following
+            // criteria:
+            // 1. The info comes from the spec itself. Other specs should
+            // already be in Specref.
+            // 2. The name ID is available, or lives in browser-specs.json.
+            // Given the way that browser-specs is maintained, a name collision
+            // means that the spec already started to appear in another source
+            // but this transition has not yet been picked up by browser-specs.
+            // That's good, no need to throw an error, let's give priority to
+            // the other source.
             const uppercaseId = spec.shortname.toUpperCase();
-            return spec.source === 'spec';
+            return spec.source === 'spec' && !isInSpecref(uppercaseId);
         })
         .forEach(function(spec) {
-            ref = convertSpec(spec);
-            
-            var id = spec.shortname;
-            var uppercaseId = id.toUpperCase();
-
-            // Spec may already exist in Specref under another name
-            var rv = bibref.reverseLookup([ref.href])[ref.href];
-            if (rv) {
+            // Add an entry to browser-specs.json for the spec, unless Specref
+            // already has an entry somewhere else for a spec with the same URL.
+            const uppercaseId = spec.shortname.toUpperCase();
+            const rv = bibref.reverseLookup([spec.url])[spec.url];
+            if (rv && !current[rv.id]) {
                 if (current[uppercaseId] &&
-                        rv.id.toUpperCase() != uppercaseId &&
-                        // avoid inadvertently catching drafts.
-                        bibref.normalizeUrl(rv.href) == bibref.normalizeUrl(ref.href)) {
-                    // Make the existing entry in browser-specs.json an alias
-                    // of the other one
+                        rv.id.toUpperCase() !== uppercaseId) {
+                    // There was an entry for this spec in browser-specs.json
+                    // but Specref has an entry for a spec with the same URL
+                    // somewhere else. Let's give that other entry priority and
+                    // mark the browser-specs entry as an alias of it.
                     updatedList[uppercaseId] = { aliasOf: rv.id };
                     return;
                 }
                 else if (!current[uppercaseId]) {
-                    // Entry did not exist in browser-specs.json, let's not
-                    // create one
+                    // There is an entry for this spec in Specref somewhere else
+                    // and we had not yet created a browser-specs.json entry.
+                    // Let's not.
                     return;
                 }
             }
 
-            if (!(uppercaseId in refs)) {
-                updatedList[uppercaseId] = ref;
-            } else {
-                var existingRef = refs[uppercaseId];
-                while (existingRef.aliasOf) { existingRef = refs[existingRef.aliasOf]; }
-                if (!("source" in existingRef) || existingRef.source == SOURCE ||
-                        bibref.normalizeUrl(ref.href) == bibref.normalizeUrl(existingRef.href)) {
-                    updatedList[uppercaseId] = ref;
-                } else {
-                    throw new Error("cannot override " + uppercaseId);
+            // No entry in Specref, let's add one
+            updatedList[uppercaseId] = convertSpec(spec);
+        });
+
+    // For continuity, add back aliases that we may have created earlier on,
+    // unless the targeted entry no longer exists (that should never happen
+    // though). Also add back entries that used to exist but that are now known
+    // under another name.
+    const browserSpecsWithFormerNames = browserSpecs.filter(s => s.formerNames);
+    Object.keys(current)
+        .filter(function(id) { return !updatedList[id]; })
+        .forEach(function(id) {
+            var ref = current[id];
+            var browserSpec = browserSpecsWithFormerNames.find(s =>
+                s.formerNames.find(n => n === id || n.toUpperCase() === id)
+            );
+            if (browserSpec) {
+                const uppercaseId = browserSpec.shortname.toUpperCase();
+                if (updatedList[uppercaseId]) {
+                    updatedList[id] = { aliasOf: uppercaseId };
+                }
+                else {
+                    let rv = bibref.reverseLookup([uppercaseId])[uppercaseId];
+                    if (!rv) {
+                        rv = bibref.reverseLookup([browserSpec.url])[browserSpec.url];
+                    }
+                    if (rv) {
+                        updatedList[id] = { aliasOf: rv.id };
+                    }
                 }
             }
+            else if (ref.aliasOf && isInSpecref(ref.aliasOf)) {
+                updatedList[id] = ref;
+            }
         });
-    // For continuity, add back aliases that we may have created earlier on,
-    // unless the targeted entry no longer exists
-    Object.keys(current).forEach(function(id) {
-        var ref = current[id];
-        if (!updatedList[id] && ref.aliasOf && refs[ref.aliasOf]) {
-            updatedList[id] = ref;
-        }
-    });
+
+    // Make sure that "obsoletedBy" properties target actual specs in Specref
+    Object.keys(updatedList)
+        .filter(function(id) { return !!updatedList[id].obsoletedBy; })
+        .forEach(function(id) {
+            var ref = updatedList[id];
+            ref.obsoletedBy = ref.obsoletedBy
+                .map(n => {
+                    if (isInSpecref(n)) {
+                        return n;
+                    }
+                    else if (isInSpecref(n.toUpperCase())) {
+                        return n.toUpperCase();
+                    }
+                    else {
+                        return null;
+                    }
+                })
+                .filter(n => !!n);
+            if (ref.obsoletedBy.length > 0) {
+                ref.isSuperseded = true;
+                if (ref.isRetired) {
+                    delete ref.isRetired;
+                }
+            }
+            else {
+                delete ref.obsoletedBy;
+            }
+        });
+
     updatedList = helper.sortRefs(updatedList);
     console.log("updating existing refs.")
     helper.writeBiblio(FILENAME, updatedList);

--- a/scripts/browser-specs.js
+++ b/scripts/browser-specs.js
@@ -108,10 +108,9 @@ request({
             updatedList[uppercaseId] = convertSpec(spec);
         });
 
-    // For continuity, add back aliases that we may have created earlier on,
-    // unless the targeted entry no longer exists (that should never happen
-    // though). Also add back entries that used to exist but that are now known
-    // under another name.
+    // For continuity, add back aliases that we may have created earlier on.
+    // Also add back entries that used to exist but that are now known under
+    // another name.
     const browserSpecsWithFormerNames = browserSpecs.filter(s => s.formerNames);
     Object.keys(current)
         .filter(function(id) { return !updatedList[id]; })
@@ -137,6 +136,9 @@ request({
             }
             else if (ref.aliasOf && isInSpecref(ref.aliasOf)) {
                 updatedList[id] = ref;
+            }
+            else {
+                throw new Error("Missing aliasOf target in browser-specs.json: " + ref.aliasOf + " needed for " + id);
             }
         });
 

--- a/scripts/run-all
+++ b/scripts/run-all
@@ -2,7 +2,7 @@
 
 node "./scripts/list-refs.js" &&
 node "./scripts/run.js" &&
-# node "./scripts/browser-specs.js" &&
+node "./scripts/browser-specs.js" &&
 node "./scripts/ietf.js" &&
 node "./scripts/w3c.js" &&
 node "./scripts/csswg.js" &&


### PR DESCRIPTION
This update leverages the new `obsoletedBy` and `formerNames` properties reported by browser-specs to:
- track spec transitions over time,
- make sure that entries in `browser-specs.json` are preserved,
- and avoid the creation of ghost entries.

In particular, on top of creating `aliasOf` relationships when needed, the script now sets `isSuperseded` and `obsoletedBy` properties - or `isRetired` - for discontinued specs.

Next time the script runs, among other minor updates, it will flag `TC39-RESIZABLEARRAYBUFFER` as superseded and obsoleted by `ECMASCRIPT`, and flag `CLOSE-WATCHER` as superseded and obsoleted by `HTML`.

This should fix #752.