### PR TITLE
Move CLDR to https

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -376,7 +376,7 @@
         "status": "Draft proposal"
     },
     "CLDR": {
-        "href": "http://cldr.unicode.org/",
+        "href": "https://cldr.unicode.org/",
         "title": "Unicode Common Locale Data Repository",
         "publisher": "Unicode Consortium"
     },


### PR DESCRIPTION
The link checker complains that http is a permanent redirect and using https is just good hygiene anyway.