### PR TITLE
Add URLPATTERN to whatwg.json and drop it from browser-specs.json

### DIFF
--- a/refs/browser-specs.json
+++ b/refs/browser-specs.json
@@ -1733,9 +1733,6 @@
         "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
         "repository": "https://github.com/WICG/ua-client-hints"
     },
-    "URLPATTERN": {
-        "aliasOf": "WHATWG-URLPATTERN"
-    },
     "USER-PREFERENCE-MEDIA-FEATURES-HEADERS": {
         "href": "https://wicg.github.io/user-preference-media-features-headers/",
         "title": "User Preference Media Features Client Hints Headers",

--- a/refs/whatwg.json
+++ b/refs/whatwg.json
@@ -254,6 +254,19 @@
         "source": "https://resources.whatwg.org/biblio.json",
         "repository": "https://github.com/whatwg/url"
     },
+    "URLPATTERN": {
+        "authors": [
+            "Ben Kelly",
+            "Jeremy Roman",
+            "宍戸俊哉 (Shunya Shishido)"
+        ],
+        "href": "https://urlpattern.spec.whatwg.org/",
+        "title": "URL Pattern Standard",
+        "status": "Living Standard",
+        "publisher": "WHATWG",
+        "source": "https://resources.whatwg.org/biblio.json",
+        "repository": "https://github.com/whatwg/urlpattern"
+    },
     "WEBIDL": {
         "authors": [
             "Edgar Chen",
@@ -598,17 +611,7 @@
         "aliasOf": "URL"
     },
     "WHATWG-URLPATTERN": {
-        "authors": [
-            "Ben Kelly",
-            "Jeremy Roman",
-            "宍戸俊哉 (Shunya Shishido)"
-        ],
-        "href": "https://urlpattern.spec.whatwg.org/",
-        "title": "URL Pattern Standard",
-        "status": "Living Standard",
-        "publisher": "WHATWG",
-        "source": "https://resources.whatwg.org/biblio.json",
-        "repository": "https://github.com/whatwg/urlpattern"
+        "aliasOf": "URLPATTERN"
     },
     "WHATWG-WEBIDL": {
         "aliasOf": "WEBIDL"


### PR DESCRIPTION
There seems to remain a transition hiccup when a WHATWG spec that was in `browser-specs.json` starts appearing in `whatwg.json`. Last update to `browser-specs.json` updated the `"URLPATTERN"` entry to flag it as an alias of `"WHATWG-URLPATTERN"`, which seems correct as there was no `"URLPATTERN"` entry in `whatwg.json`.

However, that update means that the `fetch-refs.js` script, applied to WHATWG specs, now wants to create a `"URLPATTERN"` entry in `whatwg.json`. That creates a duplicate, which prevents further scripts from running.

This update drops the alias entry from `browser-specs.json` and adds the right entry to `whatwg.json` instead. This should allow builds to resume.