### PR TITLE
Refresh the list of RFCs published under httpwg.org

### DIFF
--- a/scripts/ietf.js
+++ b/scripts/ietf.js
@@ -40,9 +40,11 @@ request({
     helper.tryOverwrite(FILE);
 });
 
-// From https://httpwg.org/specs/
-// JSON.stringify([...document.body.textContent.matchAll(/(RFC\d{4}):/g)]
-//     .map(m => m[1].toLowerCase()).sort(), null, 4);
+// From https://github.com/httpwg/httpwg.github.io/tree/main/specs
+// JSON.stringify([...new Set(
+//   [...document.querySelectorAll('div[title^=rfc]')]
+//     .map(el => el.getAttribute('title').replace(/\..*$/, '')).sort()
+// )], null, 4);
 var HTTP_SPECS = [
     "rfc2818",
     "rfc5789",
@@ -74,7 +76,22 @@ var HTTP_SPECS = [
     "rfc8297",
     "rfc8336",
     "rfc8441",
-    "rfc8470"
+    "rfc8470",
+    "rfc8941",
+    "rfc9110",
+    "rfc9111",
+    "rfc9112",
+    "rfc9113",
+    "rfc9114",
+    "rfc9204",
+    "rfc9205",
+    "rfc9209",
+    "rfc9211",
+    "rfc9213",
+    "rfc9218",
+    "rfc9220",
+    "rfc9412",
+    "rfc9440"
 ];
 
 function href(index) {


### PR DESCRIPTION
The list was no longer complete as the IETF HTTP WG published a few other RFCs.

Also, the https://httpwg.org/specs page is not such a good source for the list because it fails to list a few specs, and also contains one RFC that is actually not published under https://httpwg.org/specs. The comment explains how to extract the list from the underlying GitHub repository instead.

In terms of updates, this will swap the URL of a few additional RFC entries from `www.rfc-editor.org` to `httpwg.org/specs`, notably RFC9110, RFC9111, RFC9112 and RFC9113. That's intended, the `httpwg.org/specs` versions are more readable, as discussed in: https://github.com/w3c/browser-specs/issues/933

(Side note that updates in browser-specs to align the URLs are upcoming)