### PR TITLE
Update MSE info to handle levels 1, 2 and latest version

### DIFF
--- a/overwrites/w3c.json
+++ b/overwrites/w3c.json
@@ -12,5 +12,8 @@
   { "id": "resource-timing",   "action": "createAlias", "aliasOf": "resource-timing-2"},
   { "id": "xpath",             "action": "replaceProp", "prop": "href", "value": "https://www.w3.org/TR/xpath-10/" },
   { "id": "PNG",               "action": "renameTo", "newId": "PNG-1"},
-  { "id": "PNG",               "action": "createAlias", "aliasOf": "png-3"}
+  { "id": "PNG",               "action": "createAlias", "aliasOf": "png-3"},
+  { "id": "media-source",      "action": "renameTo", "newId": "media-source-1" },
+  { "id": "media-source-1",    "action": "replaceProp", "prop": "href", "value": "https://www.w3.org/TR/media-source-1/" },
+  { "id": "media-source",      "action": "createAlias", "aliasOf": "media-source-2" }
 ]


### PR DESCRIPTION
When MSE was published as a REC, it did not have levels. That changed. The unversioned URL now targets Level 2, which is not the Rec. The `media-source` entry in Specref is confusing as a result because it claims the spec is a Rec but links to the WD.

This update renames the shortname of the Rec from `media-source` to `media-source-1`, updates the URL for that level to `https://www.w3.org/TR/media-source-1/`, and creates a `media-source` alias to turn the `media-source` entry into a "current version" URL.

Specs that currently use `[[MEDIA-SOURCE]]` to reference MSE will now target the level 2 WD and not the level 1 Rec. All of these specs are in the Media WG, and the update is precisely meant to avoid having to update these references in the source code of these specs. HTML also references MSE but it references the Editor's Draft in any case, so nothing is going to change there...

Note that there is no generic mechanism in Specref to handle such series. Some discussion in #463.