### PR TITLE
Make the MSE alias target media-source-1

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2377,6 +2377,39 @@
     "MSE": {
         "aliasOf": "media-source"
     },
+    "MSE-20130129": {
+        "aliasOf": "media-source-1-20130129"
+    },
+    "MSE-20130415": {
+        "aliasOf": "media-source-1-20130415"
+    },
+    "MSE-20130905": {
+        "aliasOf": "media-source-1-20130905"
+    },
+    "MSE-20140109": {
+        "aliasOf": "media-source-1-20140109"
+    },
+    "MSE-20140717": {
+        "aliasOf": "media-source-1-20140717"
+    },
+    "MSE-20150331": {
+        "aliasOf": "media-source-1-20150331"
+    },
+    "MSE-20151112": {
+        "aliasOf": "media-source-1-20151112"
+    },
+    "MSE-20160503": {
+        "aliasOf": "media-source-1-20160503"
+    },
+    "MSE-20160705": {
+        "aliasOf": "media-source-1-20160705"
+    },
+    "MSE-20161004": {
+        "aliasOf": "media-source-1-20161004"
+    },
+    "MSE-20161117": {
+        "aliasOf": "media-source-1-20161117"
+    },
     "MapML": {
         "authors": [
             "Peter Rushforth",


### PR DESCRIPTION
Previous update missed the "MSE" alias that was hiding in `biblio.json`. The alias targets `media-source`, which means it now targets `media-source-2`. That's good but means that Specref can no longer resolve `MSE-YYYYMMDD` refs to the dated level 1 versions.

In turn, that makes tests fail. +1 for the consistency tests. -1 for the ability to alias names in different places!

This update creates the missing references as aliases explicitly, fixing tests.

I guess this shows that a more generic mechanism might be needed... but is not trivial ;)