### PR TITLE
Update VSS reference and introduce MQTT

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -5044,6 +5044,13 @@
             }
         }
     },
+    "VSS": {
+        "title": "Vehicle Signal Specification",
+        "href": "https://github.com/COVESA/vehicle_signal_specification",
+        "status": "4.0",
+        "date": "May 2023",
+        "publisher": "COVESA"
+    },    
     "w3c-basic-geo": {
         "href": "https://www.w3.org/2003/01/geo/",
         "title": "Basic Geo (WGS84 lat/long) Vocabulary",

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2117,6 +2117,13 @@
     "MPEGHEVC": {
         "aliasOf": "iso23008-2"
     },
+    "MQTT": {
+	title: "Message Queuing Telemetry Transport (MQTT)",
+        href: "https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html",
+        status: "5.0",
+        date: "March 2019",
+        publisher: "OASIS",
+    },
     "MSAA": {
         "href": "https://docs.microsoft.com/en-us/windows/win32/winauto/microsoft-active-accessibility",
         "title": "Microsoft Active Accessibility (MSAA)",

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -3012,6 +3012,13 @@
     "UTF-8": {
         "aliasOf": "rfc3629"
     },
+    "VSS": {
+        "title": "Vehicle Signal Specification",
+        "href": "https://github.com/COVESA/vehicle_signal_specification",
+        "status": "4.0",
+        "date": "May 2023",
+        "publisher": "COVESA"
+    },    
     "VTT708": {
         "title": "Conversion of 608/708 captions to WebVTT",
         "href": "https://dvcs.w3.org/hg/text-tracks/raw-file/default/608toVTT/608toVTT.html",
@@ -5044,13 +5051,6 @@
             }
         }
     },
-    "VSS": {
-        "title": "Vehicle Signal Specification",
-        "href": "https://github.com/COVESA/vehicle_signal_specification",
-        "status": "4.0",
-        "date": "May 2023",
-        "publisher": "COVESA"
-    },    
     "w3c-basic-geo": {
         "href": "https://www.w3.org/2003/01/geo/",
         "title": "Basic Geo (WGS84 lat/long) Vocabulary",


### PR DESCRIPTION
GENIVI relaunched as COVESA and continues to maintain VSS, presently at v4.0

OASIS' MQTT wasn't in specref so added that as well