### PR TITLE
Fix browser-specs entries for css-viewport and WASM GC proposal

### DIFF
--- a/refs/browser-specs.json
+++ b/refs/browser-specs.json
@@ -477,15 +477,7 @@
         "repository": "https://github.com/w3c/csswg-drafts"
     },
     "CSS-VIEWPORT": {
-        "href": "https://drafts.csswg.org/css-viewport/",
-        "title": "CSS Viewport Module Level 1",
-        "status": "Editor's Draft",
-        "publisher": "W3C",
-        "deliveredBy": [
-            "https://www.w3.org/Style/CSS/"
-        ],
-        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
-        "repository": "https://github.com/w3c/csswg-drafts"
+        "aliasOf": "css-viewport-1"
     },
     "CUSTOM-STATE-PSEUDO-CLASS": {
         "href": "https://wicg.github.io/custom-state-pseudo-class/",
@@ -1822,6 +1814,9 @@
         "repository": "https://github.com/WICG/video-rvfc"
     },
     "WASM-CORE-1-FORK-GC": {
+        "aliasOf": "WASM-CORE-2-FORK-GC"
+    },
+    "WASM-CORE-2-FORK-GC": {
         "href": "https://webassembly.github.io/gc/core/bikeshed/",
         "title": "WebAssembly Core Specification",
         "status": "Editor's Draft",


### PR DESCRIPTION
Automatic updates currently crash because of browser-specs and for 2 reasons:

1. css-viewport was published to /TR under a different shortname. There remains a chicken and egg issue there between the browser-specs list and the W3C list. No easy way to handle that case, this manual intervention is needed for now to create the alias ourselves.
2. The WASM GC proposal shortname changed in browser-specs from `wasm-core-1-fork-gc` to `wasm-core-2-fork-gc`, and the entry in browser-specs does not have the expected `formerNames`. That transition should have gone smoothly if the update in browser-specs had been done correctly, meaning if a `formerNames` property had been added. Will do that in browser-specs. Creating the alias manually here in the meantime.