### PR TITLE
Make ISOBMFF entry an alias of iso14496-12

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2038,12 +2038,7 @@
         "href": "https://www.iso.org/standard/69084.html"
     },
     "ISOBMFF": {
-        "title": "Information technology — Coding of audio-visual objects — Part 12: ISO Base Media File Format",
-        "href": "http://standards.iso.org/ittf/PubliclyAvailableStandards/c068960_ISO_IEC_14496-12_2015.zip",
-        "rawDate": "2015-12",
-        "status": "International Standard",
-        "publisher": "ISO/IEC",
-        "isoNumber": "ISO/IEC 14496-12:2015"
+        "aliasOf": "iso14496-12"
     },
     "ITU-R-BT.601": {
         "href": "https://www.itu.int/rec/R-REC-BT.601/",


### PR DESCRIPTION
Via https://github.com/w3c/encrypted-media/issues/523

The URL to the spec is no longer valid because the ISOBMFF spec is no longer publicly available. On top of that, it seems better to redirect to the actual entry in the ISO list of specs which is maintained automatically.