### PR TITLE
Fix resource-timing entry in W3C list

### DIFF
--- a/overwrites/w3c.json
+++ b/overwrites/w3c.json
@@ -9,7 +9,6 @@
   { "id": "dom",               "action": "delete" },
   { "id": "encoding",          "action": "delete" },
   { "id": "hr-time",           "action": "createAlias", "aliasOf": "hr-time-3"},
-  { "id": "resource-timing",   "action": "createAlias", "aliasOf": "resource-timing-2"},
   { "id": "xpath",             "action": "replaceProp", "prop": "href", "value": "https://www.w3.org/TR/xpath-10/" },
   { "id": "PNG",               "action": "renameTo", "newId": "PNG-1"},
   { "id": "PNG",               "action": "createAlias", "aliasOf": "png-3"},


### PR DESCRIPTION
The automatic update is still broken and, for once, it's not even my fault!

The resource-timing spec has a clunky history because:
- the spec started without levels, so `resource-timing`;
- then moved to levels, with `resource-timing-1` redirecting to `resource-timing-1` and then to `resource-timing-2`
- then dropped levels recently, so both `resource-timing-1` and `resource-timing-2` now redirect to `resource-timing`

With the new redirects and related information in `tr.rdf`, the W3C script goes berserk, destroys part of the history and creates an infinite loop, which crashes tests and thus prevents further automatic updates.

To avoid this, this update makes `resource-timing` the main entry point with the whole history, with levels as aliases of `resource-timing`.

This should unblock the generation and make the W3C script happy again.