### PR TITLE
Make resource-timing-1 an alias of resource-timing

### DIFF
--- a/overwrites/w3c.json
+++ b/overwrites/w3c.json
@@ -9,6 +9,8 @@
   { "id": "dom",               "action": "delete" },
   { "id": "encoding",          "action": "delete" },
   { "id": "hr-time",           "action": "createAlias", "aliasOf": "hr-time-3"},
+  { "id": "resource-timing",   "action": "deleteProp", "prop": "obsoletes"},
+  { "id": "resource-timing-1", "action": "createAlias", "aliasOf": "resource-timing"},
   { "id": "xpath",             "action": "replaceProp", "prop": "href", "value": "https://www.w3.org/TR/xpath-10/" },
   { "id": "PNG",               "action": "renameTo", "newId": "PNG-1"},
   { "id": "PNG",               "action": "createAlias", "aliasOf": "png-3"},


### PR DESCRIPTION
The update brought by #785 made `resource-timing` the main entry point for the series, listing the whole history in it, to make sure that we wouldn't lose any of the possible references.

Meanwhile, the history of the spec in the W3C system was also broken, as the system reported that the latest version was published for `resource-timing-1`. This has now been fixed, but the fix makes Specref think that `resource-timing` obsoletes `resource-timing-1` and that `resource-timing-1` has one and only one published version: the CR snapshot published on 30 March 2017. This change would make Specref lose a number of previously valid ways to reference dated versions of the spec, which gets correctly rejected by tests. In other words, auto update is blocked again.

Ideally, we'd separate the history of `resource-timing-1`, `resource-timing-2`, and `resource-timing`, but since the history has been intertwined in Specref for some time already, the easiest is to continue to treat `resource-timing` as the main entry point, and make the leveled versions aliases of them. This is what this update does, forcing `resource-timing-1` to be an alias of `resource-timing` (`resource-timing-2` is already an alias of `resource-timing` and an overwrite does not seem needed at this point).