### PR TITLE
Drop overwrite for the URL of XPath

### DIFF
--- a/overwrites/w3c.json
+++ b/overwrites/w3c.json
@@ -11,7 +11,6 @@
   { "id": "hr-time",           "action": "createAlias", "aliasOf": "hr-time-3"},
   { "id": "resource-timing",   "action": "deleteProp", "prop": "obsoletes"},
   { "id": "resource-timing-1", "action": "createAlias", "aliasOf": "resource-timing"},
-  { "id": "xpath",             "action": "replaceProp", "prop": "href", "value": "https://www.w3.org/TR/xpath-10/" },
   { "id": "PNG",               "action": "renameTo", "newId": "PNG-1"},
   { "id": "PNG",               "action": "createAlias", "aliasOf": "png-3"},
   { "id": "media-source",      "action": "renameTo", "newId": "media-source-1" },


### PR DESCRIPTION
The `xpath` entry targets version 1.0 of the spec. A change in the way the spec is handled in W3C system makes `xpath` an explicit alias of a new `xpath-10` entry. The overwrite no longer works because it attempts to add a URL to something that should only have an `aliasOf` link. This prevents automatic updates.

The overwrite is not needed for the `xpath-10` entry, as it already has the right URL. This update removes the overwrite as a result.

It could be argued that `xpath` should rather be an alias of `xpath-31`. In practice, it's not clear which version `xpath` should redirect to, and a couple of specs at least expect `xpath` to mean `xpath-10` (DOM, WebDriver, RDF XML Syntax). This is also coherent with the `xslt` entry.