### PR TITLE
Move Document Picture in Picture entry to WICG biblio

### DIFF
--- a/refs/browser-specs.json
+++ b/refs/browser-specs.json
@@ -552,17 +552,6 @@
         "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
         "repository": "https://github.com/WICG/direct-sockets"
     },
-    "DOCUMENT-PICTURE-IN-PICTURE": {
-        "href": "https://wicg.github.io/document-picture-in-picture/",
-        "title": "Document Picture-in-Picture Specification",
-        "status": "Draft Community Group Report",
-        "publisher": "W3C",
-        "deliveredBy": [
-            "https://www.w3.org/community/wicg/"
-        ],
-        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
-        "repository": "https://github.com/WICG/document-picture-in-picture"
-    },
     "ELEMENT-CAPTURE": {
         "href": "https://screen-share.github.io/element-capture/",
         "title": "Element Capture",

--- a/refs/wicg.json
+++ b/refs/wicg.json
@@ -63,6 +63,14 @@
         "source": "https://wicg.github.io/admin/biblio.json",
         "repository": "https://github.com/wicg/css-parser-api"
     },
+    "DOCUMENT-PICTURE-IN-PICTURE": {
+        "href": "https://wicg.github.io/document-picture-in-picture/",
+        "title": "Document Picture-in-Picture",
+        "status": "cg-draft",
+        "publisher": "WICG",
+        "source": "https://wicg.github.io/admin/biblio.json",
+        "repository": "https://github.com/wicg/document-picture-in-picture"
+    },
     "DOCUMENT-POLICY": {
         "href": "https://wicg.github.io/document-policy/",
         "title": "Document Policy",
@@ -370,6 +378,9 @@
     },
     "WICG-CSS-SCROLL-BOUNDARY-BEHAVIOR": {
         "aliasOf": "CSS-SCROLL-BOUNDARY-BEHAVIOR"
+    },
+    "WICG-DOCUMENT-PICTURE-IN-PICTURE": {
+        "aliasOf": "DOCUMENT-PICTURE-IN-PICTURE"
     },
     "WICG-DOCUMENT-POLICY": {
         "aliasOf": "DOCUMENT-POLICY"


### PR DESCRIPTION
The entry came from browser-specs, but has now been added to WICG biblio, and update logic still does not handle such transitions smoothly.