### PR TITLE
Make WHATWG compression entry the main one

### DIFF
--- a/refs/whatwg.json
+++ b/refs/whatwg.json
@@ -20,6 +20,17 @@
         "source": "https://resources.whatwg.org/biblio.json",
         "repository": "https://github.com/whatwg/compat"
     },
+    "COMPRESSION": {
+        "authors": [
+            "Adam Rice"
+        ],
+        "href": "https://compression.spec.whatwg.org/",
+        "title": "Compression Standard",
+        "status": "Living Standard",
+        "publisher": "WHATWG",
+        "source": "https://resources.whatwg.org/biblio.json",
+        "repository": "https://github.com/whatwg/compression"
+    },
     "CONSOLE": {
         "authors": [
             "Dominic Farolino",
@@ -548,15 +559,7 @@
         "aliasOf": "COMPAT"
     },
     "WHATWG-COMPRESSION": {
-        "authors": [
-            "Adam Rice"
-        ],
-        "href": "https://compression.spec.whatwg.org/",
-        "title": "Compression Standard",
-        "status": "Living Standard",
-        "publisher": "WHATWG",
-        "source": "https://resources.whatwg.org/biblio.json",
-        "repository": "https://github.com/whatwg/compression"
+        "aliasOf": "COMPRESSION"
     },
     "WHATWG-CONSOLE": {
         "aliasOf": "CONSOLE"

--- a/refs/wicg.json
+++ b/refs/wicg.json
@@ -31,14 +31,6 @@
         "source": "https://wicg.github.io/admin/biblio.json",
         "repository": "https://github.com/wicg/client-hints-infrastructure"
     },
-    "COMPRESSION": {
-        "href": "https://wicg.github.io/compression/",
-        "title": "Compression Streams",
-        "status": "cg-draft",
-        "publisher": "WICG",
-        "source": "https://wicg.github.io/admin/biblio.json",
-        "repository": "https://github.com/wicg/compression"
-    },
     "COOKIE-STORE": {
         "href": "https://wicg.github.io/cookie-store/",
         "title": "Cookie Store API",


### PR DESCRIPTION
The Compression spec transitioned from WICG to WHATWG but Specref continued to use the WICG entry, resulting in an outdated URL.