### PR TITLE
Drop overwrite file for WICG (no longer needed)

### DIFF
--- a/overwrites/wicg.json
+++ b/overwrites/wicg.json
@@ -1,3 +1,0 @@
-[
-    { "id": "BADGING", "action": "delete" }
-]


### PR DESCRIPTION
The WICG biblio file no longer contains anything related to BADGING and the remaining "delete" overwrite action turned into a no-op in practice (reported to the console as "Can't find BADGING in wicg.json [...]").