### PR TITLE
Fix WEBAC's title (as defined in reference) and href (to canonical)

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -3317,8 +3317,8 @@
         "aliasOf": "webdatabase"
     },
     "WEBAC": {
-        "title": "Web Access Control Ontology",
-        "href": "https://www.w3.org/ns/auth/acl",
+        "title": "Basic Access Control ontology",
+        "href": "http://www.w3.org/ns/auth/acl",
         "publisher": "W3C"
     },
     "WEBAPP-PRIVACY-BESTPRACTICES": {


### PR DESCRIPTION
This leaves the `WEBAC` entry as is but corrects the `title` and `href` values.