### PR TITLE
Adding ECMAScript 15/ES2024

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1272,6 +1272,9 @@
             "2023": {
                 "aliasOf": "ECMASCRIPT-14.0"
             },
+            "2024": {
+                "aliasOf": "ECMASCRIPT-15.0"
+            },
             "5.1": {
                 "title": "ECMA-262 Edition 5.1, The ECMAScript Language Specification",
                 "rawDate": "2011-06",
@@ -1366,6 +1369,17 @@
                 "title": "ECMA-262 14th Edition, The ECMAScript 2023 Language Specification",
                 "rawDate": "2023-06",
                 "href": "https://262.ecma-international.org/14.0/",
+                "status": "Standard",
+                "authors": [
+                    "Shu-yu Guo",
+                    "Michael Ficarra",
+                    "Kevin Gibbons"
+                ]
+            },
+            "15.0": {
+                "title": "ECMA-262 15th Edition, The ECMAScript 2024 Language Specification",
+                "rawDate": "2024-06",
+                "href": "https://262.ecma-international.org/15.0/",
                 "status": "Standard",
                 "authors": [
                     "Shu-yu Guo",


### PR DESCRIPTION
ES2024 was [approved & published on June 26th](https://ecma-international.org/news/ecma-international-approves-new-standards-9/)