### PR TITLE
OpenAPI-Learn and OpenAPI-Registry

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2783,6 +2783,16 @@
             }
         }
     },
+    "OPENAPI-LEARN": {
+        "title": "OpenAPI - Getting started, and the specification explained",
+        "href": "https://learn.openapis.org/",
+        "publisher": "OpenAPI Initiative"
+    },
+    "OPENAPI-REGISTRY": {
+        "title": "OpenAPI Initiative Registry",
+        "href": "https://spec.openapis.org/registry/index.html",
+        "publisher": "OpenAPI Initiative"
+    },
     "OPENID-CONNECT-CORE": {
         "authors": [
             "N. Sakimura",


### PR DESCRIPTION
Add two entry points related to the OpenAPI specifications:
* The OpenAPI Learn site with learning material
* The OpenAPI Registry which allows registering specification extensions

Note: draft PR to allow getting feedback from OpenAPI TSC colleagues