### PR TITLE
SPDX License List

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -3145,6 +3145,11 @@
     "SPARQL-UPDATE": {
         "aliasOf": "RDF-SPARQL-UPDATE"
     },
+    "SPDX-LICENSES": {
+        "href": "https://spdx.org/licenses/",
+        "title": "SPDX License List",
+        "publisher": "Linux Foundation"
+    },
     "SPECTRE": {
         "title": "Spectre Attacks: Exploiting Speculative Execution",
         "href": "https://spectreattack.com/spectre.pdf",


### PR DESCRIPTION
From https://spdx.org/licenses/

> The SPDX License List is an integral part of the SPDX Specification. The SPDX License List itself is a list of commonly found licenses and exceptions used in free and open or collaborative software, data, hardware, or documentation. The SPDX License List includes a standardized short identifier, the full name, the license text, and a canonical permanent URL for each license and exception.
> 
> The purpose of the SPDX License List is to enable efficient and reliable identification of such licenses and exceptions in an SPDX document, in source files or elsewhere.