### PR TITLE
Complete OpenAPI Specification versions

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2720,17 +2720,17 @@
         "publisher": "OpenAPI Initiative",
         "authors": [
             "Darrell Miller",
+            "Jason Harmon",
             "Jeremy Whitlock",
             "Marsh Gardiner",
             "Mike Ralphson",
             "Ron Ratovsky",
-            "Uri Sarid",
             "Tony Tam",
-            "Jason Harmon"
+            "Uri Sarid"
         ],
         "versions": {
             "3.1.0": {
-                "href": "http://spec.openapis.org/oas/v3.1.0",
+                "href": "https://spec.openapis.org/oas/v3.1.0",
                 "title": "OpenAPI Specification - version 3.1.0",
                 "rawDate": "2021-02-15",
                 "authors": [
@@ -2743,7 +2743,7 @@
                 ]
             },
             "3.0.3": {
-                "href": "http://spec.openapis.org/oas/v3.0.3",
+                "href": "https://spec.openapis.org/oas/v3.0.3",
                 "title": "OpenAPI Specification - version 3.0.3",
                 "rawDate": "2020-02-20",
                 "authors": [
@@ -2756,7 +2756,7 @@
                 ]
             },
             "3.0.2": {
-                "href": "http://spec.openapis.org/oas/v3.0.2",
+                "href": "https://spec.openapis.org/oas/v3.0.2",
                 "title": "OpenAPI Specification - version 3.0.2",
                 "rawDate": "2018-10-08",
                 "authors": [
@@ -2768,13 +2768,34 @@
                     "Uri Sarid"
                 ]
             },
+            "3.0.1": {
+                "href": "https://spec.openapis.org/oas/v3.0.1",
+                "title": "OpenAPI Specification - version 3.0.1",
+                "rawDate": "2017-12-06",
+                "authors": [
+                    "Darrell Miller",
+                    "Jeremy Whitlock",
+                    "Marsh Gardiner",
+                    "Mike Ralphson",
+                    "Ron Ratovsky"
+                ]
+            },
+            "3.0.0": {
+                "href": "https://spec.openapis.org/oas/v3.0.0",
+                "title": "OpenAPI Specification - version 3.0.0",
+                "rawDate": "2017-07-26",
+                "authors": [
+                    "Jeremy Whitlock",
+                    "Marsh Gardiner",
+                    "Ron Ratovsky",
+                    "Tony Tam"
+                ]
+            },
             "2.0": {
-                "href": "http://spec.openapis.org/oas/v2.0",
+                "href": "https://spec.openapis.org/oas/v2.0.html",
                 "title": "OpenAPI Specification - version 2.0",
                 "rawDate": "2014-09-08",
                 "authors": [
-                    "Darrell Miller",
-                    "Jason Harmon",
                     "Jeremy Whitlock",
                     "Marsh Gardiner",
                     "Ron Ratovsky",


### PR DESCRIPTION
* added missing versions 3.0.0, 3.0.1
* changed URLs to use `https`
* sorted overall authors list alphabetically
* corrected authors list of version 2.0