### PR TITLE
JSON Reference draft

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -5150,6 +5150,17 @@
     "json-patch-20130401": {
         "aliasOf": "rfc6902"
     },
+    "json-reference": {
+        "authors": [
+            "Paul Bryan",
+            "Kris Zyp"
+        ],
+        "href": "https://datatracker.ietf.org/doc/html/draft-pbryan-zyp-json-ref-03",
+        "publisher": "Internet Engineering Task Force (IETF)",
+        "status": "Internet-Draft",
+        "rawDate": "2012-09-16",
+        "title": "JSON Reference"
+    },
     "json-schema": {
         "authors": [
             "Austin Wright",


### PR DESCRIPTION
Adding [JSON Reference draft](https://datatracker.ietf.org/doc/html/draft-pbryan-zyp-json-ref-03) which is referenced by
* [JSON Schema Draft 04](https://datatracker.ietf.org/doc/html/draft-zyp-json-schema-04#section-10.2)
* OpenAPI [2.0](https://spec.openapis.org/oas/v2.0.html#reference-object), [3.0.0](https://spec.openapis.org/oas/v3.0.0.html#reference-object) - [3.0.3](https://spec.openapis.org/oas/v3.0.3.html#reference-object)