### PR TITLE
Stop pulling WICG's biblio file

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Unfortunately it doesn't use HTTPS yet.
 
 ### Hourly auto-updating
 
-There are [scripts](scripts/run-all) that pull fresh data from IETF, W3C, WHATWG and WICG, and update their relevant files in the `refs` directory. These are now run hourly. Their output is tested, committed and deployed without human intervention. Content should now always be up to date.
+There are [scripts](scripts/run-all) that pull fresh data from IETF, W3C, WHATWG, and other organizations, and update their relevant files in the `refs` directory. These are now run hourly. Their output is tested, committed and deployed without human intervention. Content should now always be up to date.
 
 ### Manual changes
 

--- a/refs/wicg.json
+++ b/refs/wicg.json
@@ -21,7 +21,8 @@
         "status": "cg-draft",
         "publisher": "WICG",
         "source": "https://wicg.github.io/admin/biblio.json",
-        "repository": "https://github.com/wicg/budget-api"
+        "repository": "https://github.com/wicg/budget-api",
+        "isRetired": true
     },
     "CLIENT-HINTS-INFRASTRUCTURE": {
         "href": "https://wicg.github.io/client-hints-infrastructure/",
@@ -40,12 +41,7 @@
         "repository": "https://github.com/wicg/cookie-store"
     },
     "CORS-RFC1918": {
-        "href": "https://wicg.github.io/cors-rfc1918/",
-        "title": "CORS and RFC1918",
-        "status": "cg-draft",
-        "publisher": "WICG",
-        "source": "https://wicg.github.io/admin/biblio.json",
-        "repository": "https://github.com/wicg/cors-rfc1918"
+        "aliasOf": "PRIVATE-NETWORK-ACCESS"
     },
     "CSS-PARSER-API": {
         "href": "https://wicg.github.io/css-parser-api/",
@@ -253,7 +249,8 @@
         "status": "cg-draft",
         "publisher": "WICG",
         "source": "https://wicg.github.io/admin/biblio.json",
-        "repository": "https://github.com/wicg/priority-hints"
+        "repository": "https://github.com/wicg/priority-hints",
+        "isRetired": true
     },
     "RESIZE-OBSERVER": {
         "href": "https://wicg.github.io/ResizeObserver/",
@@ -317,7 +314,11 @@
         "status": "cg-draft",
         "publisher": "WICG",
         "source": "https://wicg.github.io/admin/biblio.json",
-        "repository": "https://github.com/wicg/visual-viewport"
+        "repository": "https://github.com/wicg/visual-viewport",
+        "isSuperseded": true,
+        "obsoletedBy": [
+            "cssom-view"
+        ]
     },
     "WEB-APP-LAUNCH": {
         "href": "https://wicg.github.io/web-app-launch/",
@@ -406,7 +407,8 @@
         "status": "cg-draft",
         "publisher": "WICG",
         "source": "https://wicg.github.io/admin/biblio.json",
-        "repository": "https://github.com/wicg/frame-timing"
+        "repository": "https://github.com/wicg/frame-timing",
+        "isRetired": true
     },
     "WICG-GEOLOCATION-SENSOR": {
         "aliasOf": "geolocation-sensor"

--- a/scripts/fetch-helpers/wicg.js
+++ b/scripts/fetch-helpers/wicg.js
@@ -1,9 +1,0 @@
-module.exports = function(id, ref) {
-    return {
-        authors: ref.authors,
-        href: ref.href,
-        title: ref.title,
-        obsoletedBy: ref.obsoletedBy,
-        status: "cg-draft"
-    };
-}

--- a/scripts/run-all
+++ b/scripts/run-all
@@ -8,14 +8,12 @@ node "./scripts/w3c.js" &&
 node "./scripts/csswg.js" &&
 node "./scripts/unicode.js" &&
 node "./scripts/fetch-refs.js" "https://resources.whatwg.org/biblio.json" "WHATWG" &&
-node "./scripts/fetch-refs.js" "https://wicg.github.io/admin/biblio.json" "WICG" &&
 node "./scripts/fetch-refs.js" "https://wg21.link/index.json" "WG21" &&
 node "./scripts/fetch-refs.js" "https://dashifspecref.blob.core.windows.net/iso/iso_jtc1_sc29.json?st=2019-04-01T00%3A00%3A00Z&se=2039-04-01T00%3A00%3A00Z&sp=rl&sv=2018-03-28&sr=b&sig=Q1%2F6yLw90v0VCYKPhuSw89qLXS8tPZWU%2BQSvYj%2B7NmY%3D" "iso_jtc1_sc29" "--no-prefix" &&
 node "./scripts/fetch-refs.js" "https://dashifspecref.blob.core.windows.net/scte/scte.json?st=2019-04-01T00%3A00%3A00Z&se=2039-04-01T00%3A00%3A00Z&sp=rl&sv=2018-03-28&sr=b&sig=eIrXcpSm6WkcgRNBgNKlyMnIUGWLwgTurzYy8K2WApI%3D" "scte" "--no-prefix" &&
 node "./scripts/fetch-refs.js" "https://dashifspecref.blob.core.windows.net/etsi/etsi.json?st=2019-04-01T00%3A00%3A00Z&se=2039-04-01T00%3A00%3A00Z&sp=rl&sv=2018-03-28&sr=b&sig=J%2Fe40FI%2FkhFWRZMUEzmbr6pkNwukw6ChdjsifRaQ%2F%2Bg%3D" "etsi" "--no-prefix" &&
 node "./scripts/run.js" "./github" "csswg.json" &&
 node "./scripts/run.js" "./github" "w3c.json" &&
-node "./scripts/run.js" "./github" "wicg.json" &&
 node "./scripts/run.js" "./github" "biblio.json" &&
 node "./scripts/run.js" "./github" "whatwg.json";
 


### PR DESCRIPTION
Via https://github.com/WICG/admin/issues/190

The `biblio.json` file in WICG's admin repository has been maintained on and off in the past few years by random folks (including me). A few specs have now been retired or have moved somewhere else, and many active WICG specs do not appear in the list (for example, browser-specs contributes ~50 WICG specs to Specref that are not in WICG's `biblio.json` file). All in all, the list in browser-specs is a better source for WICG specs.

This update stops pulling updates from WICG's `biblio.json` files, making it possible to retire the file. New WICG specs will continue to be reported through the script that pulls data from browser-specs.

This update also flags retired and obsoleted WICG specs in `refs/wicg.json`, see short analysis in:
https://github.com/WICG/admin/issues/190#issuecomment-2310227541

The script that looks at updates in browser-specs won't create entries that already exist in `refs/wicg.json`. One consequence is that possible updates to existing WICG specs listed in that file require manual intervention for the time being. It may make sense to delete most entries from `refs/wicg.json` (leaving only retired specs that do not exist in browser-specs, and aliases that start with `WICG-`), and to re-create them in `refs/browser-specs.json` by running the script that pulls info from browser-specs once WICG entries have been deleted. Not done here.