### PR TITLE
Update MIDI specification reference

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2384,8 +2384,8 @@
         "aliasOf": "mediaqueries-3-20120619"
     },
     "MIDI": {
-        "href": "https://www.midi.org/specifications/item/the-midi-1-0-specification",
-        "title": "The Complete MIDI 1.0 Detailed Specification",
+        "href": "https://midi.org/midi-1-0-core-specifications",
+        "title": "MIDI 1.0 Core Specifications",
         "publisher": "The MIDI Manufacturers Association",
         "rawDate": "2014"
     },


### PR DESCRIPTION
The MIDI Manufacturer Association moved the location of their core specs on their site, and do not auto-redirect.