### PR TITLE
Move non /TR specs from w3c.json to biblio.json

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -5925,7 +5925,7 @@
     "webvr": {
         "href": "https://immersive-web.github.io/webvr/spec/1.1/",
         "title": "WebVR",
-        "status": "ED",
+        "status": "Draft Community Group Report",
         "publisher": "W3C",
         "repository": "https://github.com/immersive-web/webxr",
         "isSuperseded": true,

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -5318,7 +5318,8 @@
     },
     "media-playback-quality": {
         "authors": [
-            "Mounir Lamouri"
+            "Mounir Lamouri",
+            "Chris Cunningham"
         ],
         "href": "https://w3c.github.io/media-playback-quality/",
         "title": "Media Playback Quality",

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -5896,7 +5896,7 @@
         "href": "https://w3c.github.io/web-nfc/",
         "title": "Web NFC API",
         "status": "Draft Community Group Report",
-        "publisher": "W3C",
+        "publisher": "W3C Web NFC Community Group",
         "repository": "https://github.com/w3c/web-nfc"
     },
     "web-thing-model": {

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -5316,6 +5316,19 @@
         "href": "https://developer.mozilla.org/en-US/docs/Web/API/Element/setCapture",
         "title": "Element.setCapture()"
     },
+    "media-playback-quality": {
+        "authors": [
+            "Mounir Lamouri"
+        ],
+        "href": "https://w3c.github.io/media-playback-quality/",
+        "title": "Media Playback Quality",
+        "status": "ED",
+        "publisher": "W3C",
+        "deliveredBy": [
+            "https://www.w3.org/media-wg/"
+        ],
+        "repository": "https://github.com/w3c/media-playback-quality"
+    },
     "mediaqueries": {
         "aliasOf": "mediaqueries-4"
     },
@@ -5695,6 +5708,17 @@
             }
         }
     },
+    "staticrange": {
+        "href": "https://w3c.github.io/staticrange/",
+        "title": "Static Range",
+        "status": "ED",
+        "publisher": "W3C",
+        "repository": "https://github.com/w3c/staticrange",
+        "isSuperseded": true,
+        "obsoletedBy": [
+            "dom"
+        ]
+    },
     "typedarray": {
         "authors": [
             "David Herman",
@@ -5867,6 +5891,13 @@
         "publisher": "W3C Web Bluetooth Community Group",
         "repository": "https://github.com/webbluetoothcg/web-bluetooth"
     },
+    "web-nfc": {
+        "href": "https://w3c.github.io/web-nfc/",
+        "title": "Web NFC API",
+        "status": "ED",
+        "publisher": "W3C",
+        "repository": "https://github.com/w3c/web-nfc"
+    },
     "web-thing-model": {
         "href": "https://www.w3.org/Submission/wot-model/",
         "edDraft": "https://www.w3.org/Submission/wot-model/",
@@ -5889,6 +5920,17 @@
         "title": "WebDriver BiDi",
         "status": "Editor's Draft",
         "repository": "https://github.com/w3c/webdriver-bidi"
+    },
+    "webvr": {
+        "href": "https://immersive-web.github.io/webvr/spec/1.1/",
+        "title": "WebVR",
+        "status": "ED",
+        "publisher": "W3C",
+        "repository": "https://github.com/immersive-web/webxr",
+        "isSuperseded": true,
+        "obsoletedBy": [
+            "webxr"
+        ]
     },
     "wfs": {
         "href": "http://www.opengeospatial.org/standards/wfs",

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -5895,7 +5895,7 @@
     "web-nfc": {
         "href": "https://w3c.github.io/web-nfc/",
         "title": "Web NFC API",
-        "status": "ED",
+        "status": "Draft Community Group Report",
         "publisher": "W3C",
         "repository": "https://github.com/w3c/web-nfc"
     },

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -5926,7 +5926,7 @@
         "href": "https://immersive-web.github.io/webvr/spec/1.1/",
         "title": "WebVR",
         "status": "Draft Community Group Report",
-        "publisher": "W3C",
+        "publisher": "W3C Immersive Web Community Group",
         "repository": "https://github.com/immersive-web/webxr",
         "isSuperseded": true,
         "obsoletedBy": [


### PR DESCRIPTION
There were a few entries in `w3c.json` of specs that have not been published as working drafts, namely:
- "media-playback-quality"
- "staticrange"
- "web-nfc"
- "webrtc-insertable-streams"
- "webvr"

These specs are not /TR specs per se and do not appear in the underlying W3C source file (`tr.rdf`). This update moves these entries to `biblio.json` where they should have been added, except for "webrtc-insertable-streams", turned into an alias of "webrtc-encoded-transform".

Additionally, the "staticrange" and "webvr" entries were updated to flag the specs as having been superseded by "dom" and "webxr".

(Note: "media-playback-quality" and "web-nfc" could be provided by browser-specs down the road, but browser-specs currently uses the info provided by Specref for these specs. That creates a chicken-and-egg issue for now: the entries cannot be deleted from Specref until browser-specs gets updated, and browser-specs cannot be updated until the entries get deleted from Specref)