### PR TITLE
Make auto updates run as a GitHub action

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -1,0 +1,27 @@
+name: Auto update
+
+on:
+  schedule:
+    - cron: '10 * * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+
+    - name: Setup node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 'lts/*'
+        cache: 'npm'
+
+    - name: Run auto-update script
+      run: ./scripts/update-all
+      env:
+        GITHUB_EMAIL: ${{ vars.BOT_EMAIL }}
+        GITHUB_NAME: ${{ vars.BOT_NAME }}
+        GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+        GITHUB_REPO: https://github.com/${{ github.repository }}


### PR DESCRIPTION
The script that updates the contents of Specref currently runs as a cron job on a server. On top of costing a bit of money, this means that there is no easy way to be notified about failures to update, and no easy way to access the logs when an update fails. This update makes the `update-all` script as part of a GitHub action instead.

Preliminaries:
- The following *variables* must be defined at the repo level:
  * `BOT_NAME`, set to the GitHub account of the bot (typically: specworker)
  * `BOT_EMAIL`, set to the email of the bot
- The following *secret* must be defined at the repo level:
  * `BOT_TOKEN`, set to a "Personal access token (classic)" with `public_repo` scope in the GitHub account of the bot

@tobie, setting these variables and secret is up to you:
- For repository variables, that should be there: https://github.com/tobie/specref/settings/variables/actions
- For repository secrets, that should be there: https://github.com/tobie/specref/settings/secrets/actions
- To create a new classic token for the bot if needed: https://github.com/settings/tokens (provided you're logged in as "specworker")

(The bot account must of course have write permission on the repository. That is already the case for specworker).

The script runs every hour. It may also be triggered manually from the user interface on GitHub.

I confirmed that the workflow runs correctly on my repository. Please note however that the call to `npm install` means that the `update-all` script will re-generate `package-lock.json` upon first run, because it follows an obsolete format. I created #820 to make that update explicit and discuss possible consequences. If #820 cannot be merged beforehands, I'll update this PR to make `update-all` ignore changes made to `package-lock.json` when it pushes updates to the main branch.