### PR TITLE
Fix SMIL20 aliases and overwrite rules for media-source

### DIFF
--- a/overwrites/w3c.json
+++ b/overwrites/w3c.json
@@ -13,8 +13,6 @@
   { "id": "resource-timing-1", "action": "createAlias", "aliasOf": "resource-timing"},
   { "id": "PNG",               "action": "renameTo", "newId": "PNG-1"},
   { "id": "PNG",               "action": "createAlias", "aliasOf": "png-3"},
-  { "id": "media-source",      "action": "renameTo", "newId": "media-source-1" },
-  { "id": "media-source-1",    "action": "replaceProp", "prop": "href", "value": "https://www.w3.org/TR/media-source-1/" },
   { "id": "media-source",      "action": "createAlias", "aliasOf": "media-source-2" },
   { "id": "encrypted-media",   "action": "createAlias", "aliasOf": "encrypted-media-2" }
 ]

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -3141,12 +3141,6 @@
     "SMIL10": {
         "aliasOf": "SMIL-19980615"
     },
-    "SMIL20-20050107": {
-        "aliasOf": "SMIL2-20050107"
-    },
-    "SMIL20-20051213": {
-        "aliasOf": "SMIL2-20050107"
-    },
     "SMIME": {
         "aliasOf": "rfc3851"
     },


### PR DESCRIPTION
I'm working with @deniak on improving the data in the W3C API so that Specref may more easily switch to the W3C API. One rippling effect is that this means that some of the hacks done to get the right entries are no longer needed (and now create duplicates, which blocks automatic updates). Adjusting the rules accordingly.