### PR TITLE
Drop `access-control` from biblio.json, now handled in w3c.json

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -4028,9 +4028,6 @@
         "status": "Final",
         "title": ".ZIP File Format Specification"
     },
-    "access-control": {
-        "aliasOf": "FETCH"
-    },
     "bibo": {
         "authors": [
             "Bruce D'Arcus",


### PR DESCRIPTION
`access-control` was marked as an alias of `fetch`. That's not incorrect, but history-wise, `access-control` is more an alias of `cors`, which got superseded by `fetch`. That history wasn't properly recorded in the W3C database. It now is, so W3C update script is currently stuck because it wants to add an `access-control` entry that targets `cors`, duplicating the entry in `biblio.json`. This update drops the entry from `biblio.json`, so that updates may resume.

(The superseding relationship between `cors` and `fetch` is not properly captured yet but that's orthogonal to the problem at hand, see #829).