### PR TITLE
Add missing specs that are used in AOM (AV1)

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2139,7 +2139,7 @@
     },
     "ITU-R-BT.2100": {
         "href": "https://www.itu.int/rec/R-REC-BT.2100/",
-        "title": "Rec. ITU-R BT.2100-2, Image parameter values for high dynamic range television for use in production and international programme exchange",
+        "title": "Recommendation ITU-R BT.2100-2 (07/2018), Image parameter values for high dynamic range television for use in production and international programme exchange",
         "status": "Recommendation",
         "rawDate": "2018-07-09",
         "publisher": "ITU"

--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2137,6 +2137,13 @@
         "rawDate": "2015-06-17",
         "publisher": "ITU"
     },
+    "ITU-R-BT.2100": {
+        "href": "https://www.itu.int/rec/R-REC-BT.2100/",
+        "title": "Rec. ITU-R BT.2100-2, Image parameter values for high dynamic range television for use in production and international programme exchange",
+        "status": "Recommendation",
+        "rawDate": "2018-07-09",
+        "publisher": "ITU"
+    },
     "JAPI": {
         "href": "http://www.oracle.com/technetwork/java/javase/tech/index-jsp-140174.html",
         "title": "Java Accessibility API",
@@ -3181,6 +3188,24 @@
         "href": "http://ieeexplore.ieee.org/document/7290729/",
         "publisher": "SMPTE",
         "date": "2011"
+    },
+    "SMPTE170": {
+        "title": "ST 170, For Television - Composite Analog Video Signal - NTSC for Studio Application",
+        "href": "https://my.smpte.org/s/product-details?id=a1BVR0000008kZw",
+        "publisher": "SMPTE",
+        "date": "2004"
+    },
+    "SMPTE240": {
+        "title": "ST 240, For Television - 1125-Line High-Definition Production Systems - Signal Parameters",
+        "href": "https://my.smpte.org/s/product-details?id=a1BVR0000008kbF",
+        "publisher": "SMPTE",
+        "date": "1999"
+    },
+    "IEC61966-2-1": {
+        "title": "IEC 61966-2-1, Multimedia systems and equipment - Colour measurement and management - Part 2-1: Colour management - Default RGB colour space - sRGB",
+        "href": "https://webstore.iec.ch/en/publication/6169",
+        "publisher": "IEC",
+        "date": "1999"
     },
     "SOLID-PROTOCOL": {
         "title": "Solid Protocol",


### PR DESCRIPTION
closes #792

perhaps we also need to commit a couple of changes based on #832