### PR TITLE
DCAT versions and aliases

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -933,6 +933,9 @@
         "publisher": "DCMI",
         "status": "DCMI Recommended Resource"
     },
+    "DCAT": {
+        "aliasOf": "vocab-dcat"
+    },
     "DCDSP": {
         "authors": [
             "Mikael Nilsson"


### PR DESCRIPTION
Renamed vocab-dcat --> vocab-dcat-1 

Added 
- DCAT --> vocab-dcat
- vocab-dcat --> vocab-dcat-3 


