### PR TITLE
Drop manual webdriver-bidi entry from biblio.json

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -6015,13 +6015,6 @@
         "publisher": "W3C WoT Community Group",
         "repository": "https://github.com/webofthings/web-thing-model"
     },
-    "webdriver-bidi": {
-        "href": "https://w3c.github.io/webdriver-bidi/",
-        "publisher": "W3C",
-        "title": "WebDriver BiDi",
-        "status": "Editor's Draft",
-        "repository": "https://github.com/w3c/webdriver-bidi"
-    },
     "webvr": {
         "href": "https://immersive-web.github.io/webvr/spec/1.1/",
         "title": "WebVR",


### PR DESCRIPTION
Following publication of WebDriver BiDi to /TR, the entry is now contributed by the W3C source. This created a duplicate and prevented further auto-updates.

Note the updates to `w3c.json` is merely the result of running the `w3c.js` script to get the `webdriver-bidi` entry (among other updates)