### PR TITLE
Update URLs of W3C Patent Policy and Process documents

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -5945,7 +5945,7 @@
         "rawDate": "2006-02-01"
     },
     "w3c-patent-policy": {
-        "href": "https://www.w3.org/Consortium/Patent-Policy/",
+        "href": "https://www.w3.org/policies/patent-policy/",
         "title": "W3C Patent Policy",
         "authors": [
             "Wendy Seltzer"
@@ -5954,14 +5954,14 @@
         "rawDate": "2020-09-15"
     },
     "w3c-process": {
-        "href": "https://www.w3.org/Consortium/Process/",
+        "href": "https://www.w3.org/policies/process/",
         "title": "W3C Process Document",
         "authors": [
             "Elika J. Etemad (fantasai)",
             "Florian Rivoal"
         ],
         "publisher": "W3C",
-        "rawDate": "2021-11-02"
+        "rawDate": "2023-11-03"
     },
     "wacz": {
         "href": "https://specs.webrecorder.net/wacz/latest/",


### PR DESCRIPTION
Via https://github.com/w3c/process/issues/962

(also bumps the date of the Process document)