### PR TITLE
Creating iso14496-22-2019 & aliasing OPEN-FONT-FORMAT to that

### DIFF
--- a/refs/csswg.json
+++ b/refs/csswg.json
@@ -94,10 +94,7 @@
         "href": "https://www.w3.org/International/articles/typography/justification"
     },
     "OPEN-FONT-FORMAT": {
-        "source": "https://drafts.csswg.org/biblio.ref",
-        "title": "Information technology — Coding of audio-visual objects — Part 22: Open Font Format",
-        "publisher": "International Organization for Standardization.",
-        "href": "http://standards.iso.org/ittf/PubliclyAvailableStandards/c052136_ISO_IEC_14496-22_2009%28E%29.zip"
+        "aliasOf": "iso14496-22-2019"
     },
     "OPENTYPE": {
         "source": "https://drafts.csswg.org/biblio.ref",

--- a/refs/iso_jtc1_sc29.json
+++ b/refs/iso_jtc1_sc29.json
@@ -2893,6 +2893,13 @@
         "rawDate": "2017-08",
         "source": "https://dashifspecref.blob.core.windows.net/iso/iso_jtc1_sc29.json?st=2019-04-01T00%3A00%3A00Z&se=2039-04-01T00%3A00%3A00Z&sp=rl&sv=2018-03-28&sr=b&sig=Q1%2F6yLw90v0VCYKPhuSw89qLXS8tPZWU%2BQSvYj%2B7NmY%3D"
     },
+    "iso14496-22-2019": {
+        "href": "https://www.iso.org/standard/74461.html",
+        "title": "Information technology — Coding of audio-visual objects — Part 22: Open Font Format",
+        "status": "Published",
+        "publisher": "ISO/IEC",
+        "rawDate": "2019-01"
+    },
     "iso14496-22-2019-amd1": {
         "aliasOf": "iso14496-22-2019-amd1-2020"
     },


### PR DESCRIPTION
The `href` update to the Open Font Format as well as the creation of the `iso14496-22-2019` entry for that specific version addresses #843 and is based on the conversation there.

I removed the `source` reference due to the comments in https://github.com/w3c/csswg-drafts/pull/11433 that the CSS WG's `biblio.ref` isn't used by anything any longer. I'll create a separate issue to address completely removing SpefRef's reference/usage of https://drafts.csswg.org/biblio.ref