### PR TITLE
Support spec series and retrieve them for W3C specs

### DIFF
--- a/lib/bibref.js
+++ b/lib/bibref.js
@@ -193,6 +193,9 @@ function expandRefs(refs) {
             });
             if (ref.aliases) {
                 ref.aliases.forEach(function(aliasKey) {
+                    if (refs[aliasKey].isSeriesAlias) {
+                        return;
+                    }
                     Object.keys(versions).forEach(function(subKey) {
                         // Watch out not to overwrite existing aliases.
                         if (!refs[aliasKey + '-' + subKey]) {

--- a/schemas/raw-reference.json
+++ b/schemas/raw-reference.json
@@ -124,6 +124,10 @@
                 "aliasOf": {
                     "description": "ID of the aliased reference. Note aliasing can be recursive.",
                     "$ref": "#/definitions/id"
+                },
+                "isSeriesAlias": {
+                    "description": "Whether the alias is for the name of a specification series.",
+                    "type": "boolean"
                 }
             },
             "required": ["aliasOf"],

--- a/test/bibref.js
+++ b/test/bibref.js
@@ -12,7 +12,8 @@ suite('Test bibref api', function() {
         },
         foo: { aliasOf: "FOO" },
         bar: { aliasOf: "fOO" },
-        hello: { title: "HELLO" }
+        hello: { title: "HELLO" },
+        series: { aliasOf: "FOO", isSeriesAlias: true }
     };
 
     test('bibref constructor handles a single reference obj', function() {
@@ -54,6 +55,11 @@ suite('Test bibref api', function() {
         assert.equal("FOO title", expanded.FOO.title);
         assert.equal("BAR title", expanded["FOO-BAR"].title);
         assert.equal("FOO title", expanded["FOO-BAZ"].title);
+    });
+
+    test('bibref.expandRefs does not create versions for series aliases', function() {
+        var b = bibref.create(obj);
+        assert.ok(!('FOO' in b.get("series-BAR")), "Cannot access a spec version from a series alias.");
     });
 
     test('bibref.cleanupRefs modifies the refs correctly', function() {


### PR DESCRIPTION
This adds support for specification series, as discussed in #811. Actual changes to the core logic are minimal and should be fully transparent for consumers: a new `isSeriesAlias` boolean flag can now be added to an alias to signal that it is a "series alias". This alias gets processed by bibref exactly as any other alias, except that bibref does not create version entries when the flag is set.

In other words, given:

```
{
  "css-fonts": {
    "aliasOf": "css-fonts-4",
    "isSeriesAlias": true
  }
}
```

`css-fonts` can then be used to reference `css-fonts-4` but, as opposed to a regular alias, `css-fonts-20240201` cannot be used to reference `css-fonts-4-20240201`. This is on purpose as it allows to update `css-fonts` later on to target `css-fonts-5` when it becomes the "current" specification.

The W3C script leverages the W3C API to retrieve the list of specification series and create/update series aliases when needed and possible. First run will add 243 series aliases.

Consumers won't even know that they are dealing with a series alias, but it's not clear that they need to know in any case, and we can make that more explicit later on if needed. Similarly, this does not link specifications that belong to the same series together. For example, nothing will say that `css-color-3`, `css-color-4`, `css-color-5` are part of the series `css-color`, only that `css-color` currently targets `css-color-4`. Same thing, I don't think that consumers of Specref currently need that information and we can consider adding a link to the series from specification entries afterwards when the need arises.

I certainly do not mind using another name for `isSeriesAlias`. We don't even need to encode the fact that it is a *series* alias in practice, merely that the alias does not create version entries.

Fixes #811.