### PR TITLE
Update XMP to second edition, 2019; first edition 2012 is withdrawn

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -3984,11 +3984,11 @@
         "authors": [
             "Adobe Systems Incorporated"
         ],
-        "href": "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=57421",
+        "href": "https://www.iso.org/standard/75163.html",
         "title": "Extensible metadata platform (XMP) specification -- Part 1",
-        "rawDate": "2012-02-15",
+        "rawDate": "2019-04",
         "publisher": "ISO/IEC",
-        "isoNumber": "ISO/IEC 16684-1:2012"
+        "isoNumber": "ISO/IEC 16684-1:2019"
     },
     "XPTR-XPOINTER-CR2001": {
         "aliasOf": "xptr"


### PR DESCRIPTION
See https://www.iso.org/standard/75163.html