### PR TITLE
json-schema: reference latest IETF drafts

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -5304,9 +5304,9 @@
                     "Ben Hutton",
                     "Greg Dennis"
                 ],
-                "href": "https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00",
+                "href": "https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-01",
                 "status": "Internet-Draft",
-                "rawDate": "2020-12-08",
+                "rawDate": "2022-06-10",
                 "title": "JSON Schema: A Media Type for Describing JSON Documents. Draft 2020-12"
             },
             "05": {
@@ -5350,9 +5350,9 @@
                     "Henry Andrews",
                     "Ben Hutton"
                 ],
-                "href": "https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00",
+                "href": "https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-01",
                 "status": "Internet-Draft",
-                "rawDate": "2020-12-08",
+                "rawDate": "2022-06-10",
                 "title": "JSON Schema Validation: A Vocabulary for Structural Validation of JSON. Draft 2020-12"
             },
             "05": {


### PR DESCRIPTION
Update entries for json-schema-2020-12 and json-schema-validation-2020-12: reference latest IETF draft "-01" and update rawdate