### PR TITLE
Turn WCAG into a regular series alias

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -3557,8 +3557,35 @@
         "date": "July 2011",
         "status": "WAC Ipanema Editor's Draft"
     },
-    "WCAG": {
-        "aliasOf": "WAI-WEBCONTENT"
+    "WCAG-0203": {
+        "aliasOf": "WAI-WEBCONTENT-19980203"
+    },
+    "WCAG-0414": {
+        "aliasOf": "WAI-WEBCONTENT-19980414"
+    },
+    "WCAG-19980203": {
+        "aliasOf": "WAI-WEBCONTENT-19980203"
+    },
+    "WCAG-19980414": {
+        "aliasOf": "WAI-WEBCONTENT-19980414"
+    },
+    "WCAG-19980918": {
+        "aliasOf": "WAI-WEBCONTENT-19980918"
+    },
+    "WCAG-19990115": {
+        "aliasOf": "WAI-WEBCONTENT-19990115"
+    },
+    "WCAG-19990217": {
+        "aliasOf": "WAI-WEBCONTENT-19990217"
+    },
+    "WCAG-19990226": {
+        "aliasOf": "WAI-WEBCONTENT-19990226"
+    },
+    "WCAG-19990324": {
+        "aliasOf": "WAI-WEBCONTENT-19990324"
+    },
+    "WCAG-19990505": {
+        "aliasOf": "WAI-WEBCONTENT-19990505"
     },
     "WEB-SHARE-TARGET": {
         "authors": [
@@ -3586,7 +3613,7 @@
         "aliasOf": "appmanifest"
     },
     "WEBCONTENT": {
-        "aliasOf": "WCAG"
+        "aliasOf": "WAI-WEBCONTENT"
     },
     "WEBGL": {
         "aliasOf": "WEBGL-2"


### PR DESCRIPTION
  The `WCAG` entry had been added manually as an alias a long long time ago and still pointed at version 1.0, whereas current version is 2.2. Moving the entry to a series alias so the alias gets updated automatically from now on.

A few dated entries had to be re-created.