### PR TITLE
Force deletion of generic "draft" and "standard" WG21 entries

### DIFF
--- a/overwrites/wg21.json
+++ b/overwrites/wg21.json
@@ -2,5 +2,9 @@
   { "id": "N4762", "action": "replaceProp", "prop": "title", "value": "Working Draft, Standard for Programming Language C++" },
   { "id": "N4764", "action": "replaceProp", "prop": "title", "value": "Editors' Report: Programming Languages C++" },
   { "id": "N4778", "action": "replaceProp", "prop": "title", "value": "Working Draft, Standard for Programming Language C++" },
-  { "id": "N4779", "action": "replaceProp", "prop": "title", "value": "Editors' Report: Programming Languages C++" }
+  { "id": "N4779", "action": "replaceProp", "prop": "title", "value": "Editors' Report: Programming Languages C++" },
+  { "id": "draft", "action": "delete" },
+  { "id": "standard", "action": "delete" },
+  { "id": "WG21-draft", "action": "delete" },
+  { "id": "WG21-standard", "action": "delete" }
 ]


### PR DESCRIPTION
Two new entries got added to the WG21 JSON source recently: "draft" and "standard". Both entries have the same link, which (rightfully) makes Specref choke. On top of that, these entries have very generic names and don't make sense in Specref.

This completes the list of overwrites for WG21 to delete the "draft" and "standard" entries (and their prefixed versions that the code automatically creates).