### PR TITLE
add KERI specification to biblio.json

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2260,6 +2260,17 @@
     "JWT": {
         "aliasOf": "rfc7519"
     },
+    "KERI": {
+        "authors": [
+            "Samuel M. Smith",
+            "Phillip Feairheller"
+        ],
+        "href": "https://trustoverip.github.io/tswg-keri-specification/",
+        "title": "Key Event Receipt Infrastructure (KERI)",
+        "status": "Working Draft",
+        "publisher": "Trust Over IP Foundation",
+        "date": "2023"
+    },
     "KEYS": {
         "authors": [
             "Harold Abelson",


### PR DESCRIPTION
- Add KERI (Key Event Receipt Infrastructure) specification
- Run `npm run test` (passes)
- All entries follow existing format standards
- More info: http://trustoverip.org/ and https://lf-toip.atlassian.net/wiki/spaces/HOME/pages/100499457/2025-02-11+KSWG+Meeting+Notes