### PR TITLE
Move `digital-credentials` to `w3c.json`

### DIFF
--- a/refs/browser-specs.json
+++ b/refs/browser-specs.json
@@ -512,17 +512,6 @@
     "DIGEST-HEADERS": {
         "aliasOf": "rfc9530"
     },
-    "DIGITAL-CREDENTIALS": {
-        "href": "https://w3c-fedid.github.io/digital-credentials/",
-        "title": "Digital Credentials",
-        "status": "Editor's Draft",
-        "publisher": "W3C",
-        "deliveredBy": [
-            "https://www.w3.org/groups/wg/fedid/"
-        ],
-        "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
-        "repository": "https://github.com/w3c-fedid/digital-credentials"
-    },
     "DIGITAL-GOODS": {
         "href": "https://wicg.github.io/digital-goods/",
         "title": "Digital Goods API",
@@ -535,7 +524,7 @@
         "repository": "https://github.com/WICG/digital-goods"
     },
     "DIGITAL-IDENTITIES": {
-        "aliasOf": "DIGITAL-CREDENTIALS"
+        "aliasOf": "digital-credentials"
     },
     "DIRECT-SOCKETS": {
         "href": "https://wicg.github.io/direct-sockets/",


### PR DESCRIPTION
The Digital Credentials spec was published as FPWD. Transition from browser-specs source to W3C source should be automatic but the spec used to be known as `digital-identities` and the browser-specs script runs into a chicken-and-egg situation when it needs to handle a transition to FPWS with former names (it deletes the `digital-credentials` entry, which is good, but then needs a `digital-credentials` entry somewhere to keep the `digital-identities` alias and the entry does not yet exist in `w3c.json`)

This update makes the move manually.