### PR TITLE
Make "ETHICAL-WEB" an alias of "ethical-web-principles".

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1529,15 +1529,7 @@
         "aliasOf": "RFC2631"
     },
     "ETHICAL-WEB": {
-        "href": "https://www.w3.org/2001/tag/doc/ethical-web-principles/",
-        "title": "W3C TAG Ethical Web Principles",
-        "publisher": "W3C",
-        "status": "TAG Finding",
-        "authors": [
-            "Daniel Appelquist",
-            "Hadley Beeman"
-        ],
-        "rawDate": "2020-10-27"
+        "aliasOf": "ethical-web-principles"
     },
     "ETSI102366": {
         "aliasOf": "etsi-ts-102-366"


### PR DESCRIPTION
The version in w3.org/TR is now canonical.
