### PR TITLE
Added the set of ETSI SAREF technical specification.

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -3196,6 +3196,45 @@
     "SAREF_Patterns": {
         "aliasOf": "etsi-ts-103-548"
     },
+    "SAREF4SYST": {
+        "aliasOf": "etsi-ts-103-548"
+    },
+    "SAREF4ENER": {
+        "aliasOf": "etsi-ts-103-410-1"
+    },
+    "SAREF4ENVI": {
+        "aliasOf": "etsi-ts-103-410-2"
+    },
+    "SAREF4BLDG": {
+        "aliasOf": "etsi-ts-103-410-3"
+    },
+    "SAREF4CITY": {
+        "aliasOf": "etsi-ts-103-410-4"
+    },
+    "SAREF4INMA": {
+        "aliasOf": "etsi-ts-103-410-5"
+    },
+    "SAREF4AGRI": {
+        "aliasOf": "etsi-ts-103-410-6"
+    },
+    "SAREF4AUTO": {
+        "aliasOf": "etsi-ts-103-410-7"
+    },
+    "SAREF4EHAW": {
+        "aliasOf": "etsi-ts-103-410-8"
+    },
+    "SAREF4WEAR": {
+        "aliasOf": "etsi-ts-103-410-9"
+    },
+    "SAREF4WATR": {
+        "aliasOf": "etsi-ts-103-410-10"
+    },
+    "SAREF4LIFT": {
+        "aliasOf": "etsi-ts-103-410-11"
+    },
+    "SAREF4GRID": {
+        "aliasOf": "etsi-ts-103-410-12"
+    },
     "SCTE214": {
         "aliasOf": "SCTE214-1"
     },


### PR DESCRIPTION
This is needed for the ongoing W3C SSN specwork.

The Smart Applications REFerence (SAREF) suite of ontologies is published as a set of open standards produced by [ETSI TC SmartM2M](https://www.etsi.org/committee/smartm2m). Some references to recent technical specifications were missing or outdated.

In general, the ETSI references are mostly outdated and it would be worth re-generating file etsi.json
