### PR TITLE
Improve version sorting and inherit dates

### DIFF
--- a/lib/bibref.js
+++ b/lib/bibref.js
@@ -300,15 +300,6 @@ function addIds(refs) {
 
 var EIGHT_DIGITS = /^\d{8}$/;
 
-function findLatest(ref) {
-    var keys, latest = null;
-    if (ref.versions) {
-        keys = Object.keys(ref.versions).filter(function(k) { return EIGHT_DIGITS.test(k); }).sort();
-        latest = ref.versions[keys[keys.length - 1]];
-    }
-    return latest;
-}
-
 Bibref.prototype.get = get;
 function get(ref, output) {
     output = output || {};
@@ -377,6 +368,5 @@ module.exports.expandRefs = expandRefs;
 module.exports.createUppercaseRefs = createUppercaseRefs;
 module.exports.flattenVersions = flattenVersions;
 module.exports.cleanupRefs = cleanupRefs;
-module.exports.findLatest = findLatest;
 module.exports.normalizeUrl = normalizeUrl;
 

--- a/test/bibref.js
+++ b/test/bibref.js
@@ -81,26 +81,6 @@ suite('Test bibref api', function() {
         assert.equal(foo.deliveredBy[0].shortname, 'html', "The url http://www.w3.org/html/wg/ gets properly turned into the html shortname.");
     });
 
-    test('bibref.findLatest finds the latest version of the ref', function() {
-        var basic = {
-            versions: {
-                "20091010": { rawDate: "2009-10-10" },
-                "20100101": { rawDate: "2010-01-01" }
-            }
-        };
-        assert.equal("2010-01-01", bibref.findLatest(basic).rawDate);
-
-        var complex = {
-            versions: {
-                "20091010": { rawDate: "2009-10-10" },
-                "20100101": { rawDate: "2010-01-01" },
-                "2e": { rawDate: "1998-02-02" },
-                "999999999948393": { rawDate: "1997-02-02" }
-            }
-        };
-        assert.equal("2010-01-01", bibref.findLatest(complex).rawDate);
-    });
-
     test('bibref.flattenVersions handles date versions properly', function() {
         var cleaned = bibref.flattenVersions({
             foo: {


### PR DESCRIPTION
As a previous step to #883, this severely improves version sorting and updates the rawDate on the parent element. Previous sorting (https://api.specref.org/bibrefs?refs=ECMASCRIPT):
```
{
  "ECMASCRIPT": {
    "title": "ECMAScript Language Specification",
    "href": "https://tc39.es/ecma262/multipage/",
    "publisher": "Ecma International",
    "versions": [
      "ECMASCRIPT-9.0",
      "ECMASCRIPT-8.0",
      "ECMASCRIPT-7.0",
      "ECMASCRIPT-60",
      "ECMASCRIPT-6.0",
      "ECMASCRIPT-51",
      "ECMASCRIPT-5.1",
      "ECMASCRIPT-2025",
      "ECMASCRIPT-2024",
      "ECMASCRIPT-2023",
      "ECMASCRIPT-2022",
      "ECMASCRIPT-2021",
      "ECMASCRIPT-2020",
      "ECMASCRIPT-2019",
      "ECMASCRIPT-2018",
      "ECMASCRIPT-2017",
      "ECMASCRIPT-2016",
      "ECMASCRIPT-2015",
      "ECMASCRIPT-16.0",
      "ECMASCRIPT-15.0",
      "ECMASCRIPT-14.0",
      "ECMASCRIPT-13.0",
      "ECMASCRIPT-12.0",
      "ECMASCRIPT-11.0",
      "ECMASCRIPT-10.0"
    ],
    "repository": "https://github.com/tc39/ecma262",
    "id": "ECMASCRIPT"
  }
}
```

New sorting:
```
{
  "ECMASCRIPT": {
    "title": "ECMAScript Language Specification",
    "href": "https://tc39.es/ecma262/multipage/",
    "publisher": "Ecma International",
    "versions": [
      "ECMASCRIPT-2025",
      "ECMASCRIPT-2024",
      "ECMASCRIPT-2023",
      "ECMASCRIPT-2022",
      "ECMASCRIPT-2021",
      "ECMASCRIPT-2020",
      "ECMASCRIPT-2019",
      "ECMASCRIPT-2018",
      "ECMASCRIPT-2017",
      "ECMASCRIPT-2016",
      "ECMASCRIPT-2015",
      "ECMASCRIPT-60",
      "ECMASCRIPT-51",
      "ECMASCRIPT-16.0",
      "ECMASCRIPT-15.0",
      "ECMASCRIPT-14.0",
      "ECMASCRIPT-13.0",
      "ECMASCRIPT-12.0",
      "ECMASCRIPT-11.0",
      "ECMASCRIPT-10.0",
      "ECMASCRIPT-9.0",
      "ECMASCRIPT-8.0",
      "ECMASCRIPT-7.0",
      "ECMASCRIPT-6.0",
      "ECMASCRIPT-5.1"
    ],
    "repository": "https://github.com/tc39/ecma262",
    "id": "ECMASCRIPT"
  }
}
```

An old, redundant and buggy unused version has been also dropped for cleanup.