### PR TITLE
Update NDE Requirements for Datasets URL

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -2929,7 +2929,7 @@
             "David de Boer",
             "Bob Coret"
         ],
-        "href": "https://netwerk-digitaal-erfgoed.github.io/requirements-datasets/",
+        "href": "https://docs.nde.nl/requirements-datasets/",
         "title": "NDE Requirements for Datasets",
         "status": "Living Specification",
         "publisher": "NDE",


### PR DESCRIPTION
The NDE Requirements for Datasets specification has moved from netwerk-digitaal-erfgoed.github.io to docs.nde.nl.