### PR TITLE
Fix: FOAF missing trailing slash

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1711,7 +1711,7 @@
             "Dan Brickley",
             "Libby Miller"
         ],
-        "href": "http://xmlns.com/foaf/spec",
+        "href": "http://xmlns.com/foaf/spec/",
         "title": "FOAF Vocabulary Specification 0.99 (Paddington Edition)",
         "rawDate": "2014-01-14",
         "publisher": "FOAF project",


### PR DESCRIPTION
The canonical identifier for the namespace uses a trailing slash:

* http://xmlns.com/foaf/spec/
* https://xmlns.com/foaf/spec/

Also, without a trailing slash, it currently leads to a broken redirect chain:

* http://xmlns.com/foaf/spec
* https://xmlns.com/foaf/spec
* http://xmlns.com:8080/foaf/spec/
* Trying multiple IPv6 and IPv4 addresses on TCP port 8080
* Timeout; or none of the IP addresses have port 8080 open