### PR TITLE
Adjust IETF logic for new RFC Editor site

### DIFF
--- a/overwrites/ietf.json
+++ b/overwrites/ietf.json
@@ -1,4 +1,3 @@
 [
-  { "id": "rfc1384", "action": "replaceProp", "prop": "obsoletedBy", "value": ["rfc1617"] },
-  { "id": "rfc0200", "action": "replaceProp", "prop": "obsoletedBy", "value": ["RFC-INDEX"] }
+  { "id": "rfc200", "action": "replaceProp", "prop": "obsoletedBy", "value": ["RFC-INDEX"] }
 ]

--- a/schemas/raw-reference.json
+++ b/schemas/raw-reference.json
@@ -205,7 +205,7 @@
                 "rfcNumber": {
                     "description": "Number of IETF RFC",
                     "type": "string",
-                    "pattern": "^(BCP|RFC)\\d{4}$"
+                    "pattern": "^(BCP|RFC)\\d{1,4}$"
                 },
                 "isoNumber": {
                     "description": "Number of ISO standard",

--- a/scripts/ietf.js
+++ b/scripts/ietf.js
@@ -4,7 +4,7 @@ var request = require('request'),
     helper = require('./helper'),
     xml2js = require('xml2js');
 
-var RFC_URL = "https://www.rfc-editor.org/in-notes/rfc-index.xml";
+var RFC_URL = "https://www.ietf.org/rfc/rfc-index.xml";
 var FILE = "ietf.json";
 
 var current = helper.readBiblio(FILE);
@@ -27,10 +27,10 @@ request({
     parser.parseString(body, function (err, result) {
         result["rfc-index"]["rfc-entry"].map(formatData).forEach(function(obj) {
             var id = obj.rfcNumber.toLowerCase();
-            var unpadded = unpad(id);
+            var padded = padRfcNumber(id);
             current[id] = obj;
-            if (unpadded !== id) {
-                current[unpadded] = { aliasOf: id };
+            if (padded !== id) {
+                current[padded] = { aliasOf: id };
             }
         });
     });
@@ -99,14 +99,15 @@ function href(index) {
     if (HTTP_SPECS.indexOf(index) > -1) {
         return "https://httpwg.org/specs/" + index + ".html";
     }
-    if (index.indexOf("bcp") == 0) {
-        return "https://www.rfc-editor.org/info/" + unpad(index);
-    }
-    return "https://www.rfc-editor.org/rfc/" + unpad(index);
+    return "https://www.rfc-editor.org/info/" + index + "/";
 }
 
-function unpad(index) {
-    return index.replace(/(rfc|bcp)0*(\d+)/i, "$1$2");
+function padRfcNumber(index) {
+    const match = index.match(/^(rfc|bcp)0*(\d+)/i);
+    if (match) {
+        return match[1] + match[2].padStart(4, "0");
+    }
+    return index;
 }
 
 var MONTHS = [


### PR DESCRIPTION
IETF released a new RFC Editor site last week. The `rfc-index.xml` file is no longer available (related PR: https://github.com/ietf-tools/red/pull/268) at the URL that the IETF script was using. A similar index file is available from:
  https://www.ietf.org/rfc/rfc-index.xml

The new RFC Editor site also changes all URLs
from `http://www.rfc-editor.org/rfc/rfcXXXX`
to `http://www.rfc-editor.org/info/rfcXXXX/`

This update adjusts the IETF script to the new site and index.

The new index file no longer pads rfc numbers by default, e.g., it has `RFC1` instead of `RFC0001`. The script created an entry for `rfc0001` and an alias for `rfc1`. To better align with the new RFC index, it now does the opposite: it creates an entry for `rfc1` and an alias for `rfc0001`.

The `obsoletes`, `updatedBy, `obsoletedBy` properties now also target unpadded RFC numbers.

(The script could rather be tweaked to do the opposite and keep padded RFC numbers as the main reference, but the code would be more convoluted and both the unpadded and padded entries continue to exist for consumers in any case.)

One of the IETF overwrites needed to be adjusted as well. The other one was no longer needed and was dropped.

Note that the raw schema had to be relaxed to allow for an unpadded `rfcNumber`. This should not create any issue as that property is not exposed by the API.