### PR TITLE
COMPRESSION-DICTIONARY, DIGEST-HEADERS, and WEBP are now published RFCs

### DIFF
--- a/refs/browser-specs.json
+++ b/refs/browser-specs.json
@@ -268,9 +268,6 @@
         "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
         "repository": "https://github.com/w3c/csswg-drafts"
     },
-    "COMPRESSION-DICTIONARY": {
-        "aliasOf": "rfc9842"
-    },
     "CONNECTION-ALLOWLISTS": {
         "href": "https://wicg.github.io/connection-allowlists/",
         "title": "Connection Allowlists",
@@ -548,9 +545,6 @@
         ],
         "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
         "repository": "https://github.com/WICG/WebApiDevice"
-    },
-    "DIGEST-HEADERS": {
-        "aliasOf": "rfc9530"
     },
     "DIGITAL-GOODS": {
         "href": "https://wicg.github.io/digital-goods/",
@@ -3255,9 +3249,6 @@
         ],
         "source": "https://raw.githubusercontent.com/w3c/browser-specs/web-specs%40latest/index.json",
         "repository": "https://github.com/webmachinelearning/webmcp"
-    },
-    "WEBP": {
-        "aliasOf": "rfc9649"
     },
     "WEBPACKAGE": {
         "href": "https://wicg.github.io/webpackage/loading.html",


### PR DESCRIPTION
The auto-update script has been failing because these 3 documents are now RFCs and are being dropped from `refs/browser-specs.json`