### PR TITLE
Security: Prototype Pollution via Object Property Assignment

### DIFF
--- a/scripts/fetch-refs.js
+++ b/scripts/fetch-refs.js
@@ -17,6 +17,10 @@ var HELPER = "./fetch-helpers/" + PUBLISHER.toLowerCase();
 
 var biblio = helper.readBiblio();
 var current = helper.readBiblio(FILENAME);
+
+function isValidKey(key) {
+    return key !== '__proto__' && key !== 'constructor' && key !== 'prototype';
+}
 var refs = bibref.createUppercaseRefs(bibref.expandRefs(bibref.raw));
 console.log("Updating", PUBLISHER, "references...");
 console.log("Fetching", SOURCE + "...");
@@ -34,6 +38,9 @@ request({
     console.log("Parsing", SOURCE + "...");
     var json = JSON.parse(body);
     Object.keys(json).forEach(function(id) {
+        if (!isValidKey(id)) {
+            throw new Error("Invalid key: " + id);
+        }
         var ref = json[id];
         if (ref.aliasOf) {
             ref = { aliasOf: ref.aliasOf };
@@ -45,6 +52,9 @@ request({
         }
         var uppercaseId = id.toUpperCase();
         var prefixedId = PUBLISHER + "-" + id;
+        if (!isValidKey(prefixedId)) {
+            throw new Error("Invalid key: " + prefixedId);
+        }
         if (!(uppercaseId in refs)) {
             current[id] = ref;
             if (PREFIX) { current[prefixedId] = { aliasOf: id }; }
@@ -66,6 +76,9 @@ request({
                 rv.id.toUpperCase() != prefixedId.toUpperCase() &&
                 // avoid inadvertently catching drafts.
                 bibref.normalizeUrl(rv.href) == bibref.normalizeUrl(ref.href)) {
+            if (!isValidKey(rv.id)) {
+                throw new Error("Invalid key: " + rv.id);
+            }
             current[rv.id] = { aliasOf: PREFIX ? prefixedId : id };
             delete biblio[rv.id];
         }


### PR DESCRIPTION
## Summary

Security: Prototype Pollution via Object Property Assignment

## Problem

**Severity**: `High` | **File**: `scripts/fetch-refs.js:L35`

In scripts/fetch-refs.js, the code dynamically requires a module based on user-controlled input: `require(HELPER)` where `HELPER = "./fetch-helpers/" + PUBLISHER.toLowerCase()`. While the path is partially constrained, the `PUBLISHER` variable comes from `process.argv[3]`. More critically, the code assigns properties to objects without checking for prototype pollution: `current[id] = ref` and `current[prefixedId] = { aliasOf: id }`. If `id` or `prefixedId` were to be `__proto__`, `constructor`, or `prototype`, this could pollute the object prototype. Though the id comes from external JSON, the lack of sanitization on object keys before assignment creates a prototype pollution risk.

## Solution

Sanitize all object keys before assignment by checking against `__proto__`, `constructor`, and `prototype`. Use `Object.create(null)` for maps that store user-controlled keys, or implement a helper function to validate keys: `if (['__proto__', 'constructor', 'prototype'].includes(key)) throw new Error('Invalid key');`

## Changes

- `scripts/fetch-refs.js` (modified)