### PR TITLE
add CTAP 2.3 reference

### DIFF
--- a/refs/fido.json
+++ b/refs/fido.json
@@ -1,0 +1,9 @@
+{
+  "CTAP-2.3": {
+    "href": "https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html",
+    "title": "Client to Authenticator Protocol (CTAP) Version 2.3",
+    "publisher": "FIDO Alliance",
+    "status": "Proposed Standard",
+    "rawDate": "2026-02-26"
+  }
+}


### PR DESCRIPTION
This PR adds the newly published FIDO CTAP 2.3 Proposed Standard published on February 26, 2026.