### PR TITLE
WebGL updates

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -3755,12 +3755,10 @@
     },
     "WEBGL-1": {
         "authors": [
-            "Dean Jackson",
-            "Jeff Gilbert"
+            "Kelsey Gilbert"
         ],
         "href": "https://www.khronos.org/registry/webgl/specs/latest/1.0/",
         "title": "WebGL Specification, Version 1.0",
-        "rawDate": "2017-08-09",
         "publisher": "Khronos",
         "repository": "https://github.com/KhronosGroup/WebGL",
         "versions": {
@@ -3768,7 +3766,7 @@
                 "authors": [
                     "Dean Jackson"
                 ],
-                "href": "https://www.khronos.org/registry/webgl/specs/1.0.3/",
+                "href": "https://registry.khronos.org/webgl/specs/1.0.3/",
                 "title": "WebGL Specification",
                 "rawDate": "2014-10-27"
             }
@@ -3779,14 +3777,26 @@
     },
     "WEBGL-2": {
         "authors": [
-            "Dean Jackson",
-            "Jeff Gilbert"
+            "Kelsey Gilbert"
         ],
         "href": "https://www.khronos.org/registry/webgl/specs/latest/2.0/",
         "title": "WebGL 2.0 Specification",
-        "rawDate": "2017-08-12",
         "publisher": "Khronos",
-        "repository": "https://github.com/KhronosGroup/WebGL"
+        "repository": "https://github.com/KhronosGroup/WebGL",
+        "versions": {
+            "20170411": {
+                "authors": [
+                    "Dean Jackson",
+                    "Jeff Gilbert"
+                ],
+                "href": "https://registry.khronos.org/webgl/specs/2.0.0/",
+                "title": "WebGL 2 Specification",
+                "rawDate": "2017-04-11"
+            }
+        }
+    },
+    "WEBGL-200": {
+        "aliasOf": "WEBGL-2-20170411"
     },
     "WEBINTENTS": {
         "authors": [


### PR DESCRIPTION
[WEBGL-1](https://www.specref.org/?q=webgl-1) & [WEBGL-2](https://www.specref.org/?q=webgl-2) point to the Editors Draft of those versions. There is no current entry for the [official WebGL 2.0.0 version](https://registry.khronos.org/webgl/specs/2.0.0/).

Given that, this commit makes the following updates:
- WEBGL-1 Author updated to the current editor & removed the date
- WEBGL-1-20141027 href updated to where the prior URL currently redirects to
- WEBGL-2 Author updated to the current editor & removed the date
- Added WEBGL-2-20170411 to be a reference to the official WebGL 2.0.0 version
- Added WEBGL-200 as an alias of WEBGL-2-20170411, matching the pattern of WEBGL-103 being an alias of WEBGL-1-20141027