### PR TITLE
Adding ECMAScript 17/ES2026

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -1416,6 +1416,9 @@
             "2025": {
                 "aliasOf": "ECMASCRIPT-16.0"
             },
+            "2026": {
+                "aliasOf": "ECMASCRIPT-17.0"
+            },
             "5.1": {
                 "title": "ECMA-262 Edition 5.1, The ECMAScript Language Specification",
                 "rawDate": "2011-06",
@@ -1532,6 +1535,17 @@
                 "title": "ECMA-262 16th Edition, The ECMAScript 2025 Language Specification",
                 "rawDate": "2025-06",
                 "href": "https://262.ecma-international.org/16.0/",
+                "status": "Standard",
+                "authors": [
+                    "Shu-yu Guo",
+                    "Michael Ficarra",
+                    "Kevin Gibbons"
+                ]
+            },
+            "17.0": {
+                "title": "ECMA-262 17th Edition, The ECMAScript 2026 Language Specification",
+                "rawDate": "2026-06",
+                "href": "https://262.ecma-international.org/17.0/",
                 "status": "Standard",
                 "authors": [
                     "Shu-yu Guo",


### PR DESCRIPTION
ECMAScript 2026 was [approved & published on June 30th](https://ecma-international.org/news/ecma-international-approves-new-standards-14/)